### PR TITLE
Gravatar Support for Contact Emails

### DIFF
--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -951,7 +951,7 @@ class SugarEmailAddress extends SugarBean {
             $key = ($addressItem['invalid_email'] == 1) ? 'invalid' : $key;
             $key = ($addressItem['opt_out'] == 1) && ($addressItem['invalid_email'] == 1) ? 'opt_out_invalid' : $key;
 
-            $assign[] = array('key' => $key, 'address' => $current_user->getEmailLink2($addressItem['email_address'], $focus).$addressItem['email_address']."</a>");
+	    $assign[] = array('key' => $key, 'address' => $current_user->getEmailLink2($addressItem['email_address'], $focus).$addressItem['email_address']."</a>",      'hash' => md5(strtolower(trim($addressItem['email_address']))));
         }
 
 

--- a/include/SugarEmailAddress/SugarEmailAddress.php
+++ b/include/SugarEmailAddress/SugarEmailAddress.php
@@ -951,7 +951,11 @@ class SugarEmailAddress extends SugarBean {
             $key = ($addressItem['invalid_email'] == 1) ? 'invalid' : $key;
             $key = ($addressItem['opt_out'] == 1) && ($addressItem['invalid_email'] == 1) ? 'opt_out_invalid' : $key;
 
-	    $assign[] = array('key' => $key, 'address' => $current_user->getEmailLink2($addressItem['email_address'], $focus).$addressItem['email_address']."</a>",      'hash' => md5(strtolower(trim($addressItem['email_address']))));
+	    list($emailUser, $emailDomain) = explode('@', $addressItem['email_address']);
+            $altImg = urlencode("https://logo.clearbit.com/$emailDomain");
+
+            $assign[] = array('key' => $key, 'address' => $current_user->getEmailLink2($addressItem['email_address'], $focus).$addressItem['email_address']."</a>", 'hash' => md5(strtolower(trim($addressItem['email_address']))), 'alt_img' => $altImg);
+
         }
 
 

--- a/include/SugarEmailAddress/templates/forDetailView.tpl
+++ b/include/SugarEmailAddress/templates/forDetailView.tpl
@@ -51,6 +51,7 @@
 							<i>
 						{/if}
 
+						<a href='https://www.gravatar.com/avatar/{$address.hash}?s=200' target='_blank'><img src='https://www.gravatar.com/avatar/{$address.hash}?s=25' /></a>
 						{$address.address}
 
 						{if $address.key === 'primary'}

--- a/include/SugarEmailAddress/templates/forDetailView.tpl
+++ b/include/SugarEmailAddress/templates/forDetailView.tpl
@@ -51,7 +51,7 @@
 							<i>
 						{/if}
 
-						<a href='https://www.gravatar.com/avatar/{$address.hash}?s=200' target='_blank'><img src='https://www.gravatar.com/avatar/{$address.hash}?s=25' /></a>
+						<a href='https://www.gravatar.com/avatar/{$address.hash}?s=200&d={$address.alt_img}' target='_blank'><img style='width:25px;height:25px'src='https://www.gravatar.com/avatar/{$address.hash}?s=25&d={$address.alt_img}' /></a>
 						{$address.address}
 
 						{if $address.key === 'primary'}


### PR DESCRIPTION
## Description

This change shows Gravatar images for each email in the detail view. 
(Closed the previous pull request which I apparently made for the wrong branch, https://github.com/salesagility/SuiteCRM/pull/1686)

## Motivation and Context

When managing a large number of accounts or leads it can be really useful to have a graphical association with the contact in addition to the name. Gravatar is not super popular yet but it's an easy add-on which doesn't require any additional work for the user.
## How Has This Been Tested?

I actually deployed this for our company live system. 

![gravatar](https://cloud.githubusercontent.com/assets/1142090/16533837/63c312f0-3f90-11e6-8e4b-02791af3c607.png)
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
