### PR TITLE
Listview filter doesn't work when trying to search an enum field with a subquery

### DIFF
--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -1030,7 +1030,7 @@ class SearchForm
                                 if (!empty($field_value)) {
                                     $field_value .= ',';
                                 }
-                                if ($operator == 'subquery') {
+                                if ($operator == 'subquery' && $parms['type'] !== 'enum') {
                                     $field_value .= $val;
                                 } else {
                                     $field_value .= $db->quoteType($type, $val);
@@ -1297,7 +1297,13 @@ class SearchForm
                                     if (!empty($parms['subquery'])) {
                                         $selectCol = $this->getSelectCol($parms['subquery']);
                                     }
-                                    $where .= "{$db_field} $in (select $selectCol from ({$parms['subquery']} " . $this->seed->db->quoted($field_value . '%') . ") {$field}_derived)";
+                                    if ($operator == 'subquery' && $parms['type'] !== 'enum') {
+                                        $where .= "{$db_field} $in (select $selectCol from ({$parms['subquery']} " . $this->seed->db->quoted($field_value . '%') . ") {$field}_derived)";
+                                    }else{
+                                        $parms['subquery'] = str_replace('LIKE', 'IN', $parms['subquery']);
+                                        $where .= "{$db_field} $in (select $selectCol from ({$parms['subquery']} " . '(' . $field_value . ')' . ") {$field}_derived)";
+
+                                    }
                                 }
 
                                 break;


### PR DESCRIPTION
Altered the sql query that is used for list view when field is an enum
and has a subquery. Fix for issue #6434

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Altered the sql query for when an enum field has a subquery. Due to the way enums are saved in database query has to be changed to use 'IN' operator instead of 'LIKE' operator.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves issue with enums fields for listview filters

## How To Test This
<!--- Please describe in detail how to test your changes. -->
See issue #6434

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->