### PR TITLE
Fix #8388 - Add userID as optional argument in SugarLogger log method

### DIFF
--- a/include/SugarLogger/SugarLogger.php
+++ b/include/SugarLogger/SugarLogger.php
@@ -196,15 +196,18 @@ class SugarLogger implements LoggerTemplate
      */
     public function log(
         $level,
-        $message
-        ) {
+        $message,
+        $userID = null
+    ) {
         global $sugar_config;
 
         if (!$this->initialized) {
             return;
         }
         //lets get the current user id or default to -none- if it is not set yet
-        $userID = (!empty($GLOBALS['current_user']->id))?$GLOBALS['current_user']->id:'-none-';
+        if (empty($userID)) {
+            $userID = (!empty($GLOBALS['current_user']->id))?$GLOBALS['current_user']->id:'-none-';
+        }
 
         //if we haven't opened a file pointer yet let's do that
         if (! $this->fp) {


### PR DESCRIPTION
Add an optional argument $userID to log method, with default value null.
When this value is not empty, use it. Otherwise, use UUID (current behaviour).

## Description
Fix #8388 

## Motivation and Context
See #8388 

## How To Test This
1. Extend SugarLogger class.
2. Override log method.
3. Provide any string, for example the current user's `user_name` as the userID parameter in log method.
4. Ensure this class writes the log.
5. Check log file to see that the user `UUID` is now replaced by `user_name` in each log line. 
6. When using SugarLogger directly nothing should change.

It can be tested this using the following example method in MyLogger class (extend it from SugarLogger) in `custom/include/SugarLogger/MyLogger.php`:

```php
    public function log($level, $message, $userName = null)
    {
        $userName = !empty($GLOBALS['current_user']->user_name) ? $GLOBALS['current_user']->user_name : null;
        parent::log($level, $message, $userName);
    }
```
And don't forget to turn off SugarLogger with log mapping level or configure it to be able to recognize the logs written by each class (SugarLogger and MyLogger). 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->