### PR TITLE
Fix invalid SQL generated from SOAP call to get_entry_list

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -3369,6 +3369,7 @@ class Email extends Basic
 
         $query .= $custom_join['join'];
 
+        $where_auto = "1=1";
         if ($show_deleted == 0) {
             $where_auto = " emails.deleted=0 \n";
         } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
This fixes an error in the SOAP call to get_entry_list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix invalid SQL generated from SOAP call to get_entry_list for Emails
    
$where_auto was empty when $show_deleted was neither 0 or 1
(e.g. service/v4/SugarWebServiceImplv4.php sets it to -1 to signify
"both deleted and non-deleted objects").
    
However the code in Emails.php would generate an invalid SQL query
if $where_auto was empty:
```
            if ($where != "") {
                $query .= "WHERE $where AND " . $where_auto;
            } else {
                $query .= "WHERE " . $where_auto;
            }
```
... which leads to a query ending in "AND" with nothing after that.
Obviously this leads to "You have an error in your SQL syntax [...]"
    
The solution of initializing $where_auto to "1=1" is the one used in other files like Opportunity.php


## How To Test This
My client application (https://github.com/KDAB/FatCRM) is making SOAP calls to SuiteCRM.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->