### PR TITLE
Better check for not empty than isset

### DIFF
--- a/data/Relationships/One2MBeanRelationship.php
+++ b/data/Relationships/One2MBeanRelationship.php
@@ -408,7 +408,7 @@ class One2MBeanRelationship extends One2MRelationship
 
     public function getRelationshipTable()
     {
-        if (isset($this->def['table'])) {
+        if (!empty($this->def['table'])) {
             return $this->def['table'];
         }
         return $this->def['rhs_table'];


### PR DESCRIPTION
For me i following problem:
I have a custom module that has the column "parent_type" in the database.
Now i added activities to that custom module and I got an MySQL-Error on ambigous column "parent_type"
Hunted it down to where the table name wont be added to the query.

The resulting query looked like following, you can see the table name is not in the ON clause.
With my patch it fixes that.


`( SELECT count(*) c FROM meetings  LEFT JOIN meetings_cstm ON meetings.id = meetings_cstm.id_c  
INNER JOIN  nx_lieferschein nx_lieferschein_activities_meetings_rel ON meetings.parent_id=nx_lieferschein_activities_meetings_rel.id AND nx_lieferschein_activities_meetings_rel.deleted=0
 AND parent_type = 'nx_lieferschein'
 where ( meetings.parent_id='301680ce-32d4-17bf-1474-5e7cb6415439' AND (meetings.status !='Held' AND meetings.status !='Not Held')) AND meetings.deleted=0 ) 
 UNION ALL 
 ( SELECT count(*) c FROM tasks  INNER JOIN  nx_lieferschein nx_lieferschein_activities_tasks_rel ON tasks.parent_id=nx_lieferschein_activities_tasks_rel.id AND nx_lieferschein_activities_tasks_rel.deleted=0
 AND parent_type = 'nx_lieferschein'
 where ( tasks.parent_id='301680ce-32d4-17bf-1474-5e7cb6415439' AND (tasks.status != 'Completed' AND tasks.status != 'Deferred')) AND tasks.deleted=0 ) 
  UNION ALL ( SELECT count(*) c FROM calls  INNER JOIN  nx_lieferschein nx_lieferschein_activities_calls_rel 
 ON calls.parent_id=nx_lieferschein_activities_calls_rel.id AND nx_lieferschein_activities_calls_rel.deleted=0
 AND parent_type = 'nx_lieferschein'
 where ( calls.parent_id='301680ce-32d4-17bf-1474-5e7cb6415439' AND (calls.status != 'Held' AND calls.status != 'Not Held')) AND calls.deleted=0 )`