### PR TITLE
API V8 updates for better custom field support, less stringent REGEX, and related Bean attributes

### DIFF
--- a/Api/V8/BeanDecorator/BeanManager.php
+++ b/Api/V8/BeanDecorator/BeanManager.php
@@ -227,7 +227,7 @@ class BeanManager
                     strtok($where, '.'),
                     $this->newBeanSafe($module)->getTableName(),
                     $where === '' ? '' : 'WHERE ' .  $where
-                   );         
+                   );
         }
         $rowCount = $this->db->fetchRow($this->db->query($query))["cnt"];
 

--- a/Api/V8/BeanDecorator/BeanManager.php
+++ b/Api/V8/BeanDecorator/BeanManager.php
@@ -216,15 +216,20 @@ class BeanManager
      */
     public function countRecords($module, $where)
     {
-        $rowCount = $this->db->fetchRow(
-            $this->db->query(
-                sprintf(
-                    "SELECT COUNT(*) AS cnt FROM %s %s",
+        $query = sprintf(
+                  "SELECT COUNT(*) AS cnt FROM %s %s",
+                  $this->newBeanSafe($module)->getTableName(),
+                  $where === '' ? '' : 'WHERE ' .  $where
+                 );
+        if (strtok($where,".") != $this->newBeanSafe($module)->getTableName()) {
+          $query = sprintf(
+                    "SELECT COUNT(*) AS cnt FROM %s, %s %s",
+                    strtok($where, '.'),
                     $this->newBeanSafe($module)->getTableName(),
                     $where === '' ? '' : 'WHERE ' .  $where
-                )
-            )
-        )["cnt"];
+                   );         
+        }
+        $rowCount = $this->db->fetchRow($this->db->query($query))["cnt"];
 
         return (int)$rowCount;
     }

--- a/Api/V8/JsonApi/Helper/AttributeObjectHelper.php
+++ b/Api/V8/JsonApi/Helper/AttributeObjectHelper.php
@@ -33,7 +33,7 @@ class AttributeObjectHelper
         $attributes = array_map(function ($value) {
             return is_string($value)
                 ? (\DateTime::createFromFormat('Y-m-d H:i:s', $value)
-                    ? date(\DateTime::ATOM, strtotime($value))
+                    ? date(\DateTime::ATOM, strtotime($value." UTC"))
                     : $value)
                 : $value;
         }, $bean->toArray());

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -47,7 +47,12 @@ class Filter
 
         $where = [];
         foreach ($params as $field => $expr) {
-            if (empty($bean->field_defs[$field])) {
+            $tableName = "";
+            if ($bean->field_name_map[$field] != NULL)
+            {
+              if ($bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
+              else $tableName = $bean->getTableName();
+            } else {
                 throw new \InvalidArgumentException(sprintf(
                     'Filter field %s in %s module is not found',
                     $field,
@@ -63,7 +68,7 @@ class Filter
                 $this->checkOperator($op);
                 $where[] = sprintf(
                     '%s.%s %s %s',
-                    $bean->getTableName(),
+                    $tableName,
                     $field,
                     constant(sprintf('%s::OP_%s', self::class, strtoupper($op))),
                     $this->db->quoted($value)

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -48,7 +48,7 @@ class Filter
         $where = [];
         foreach ($params as $field => $expr) {
             $tableName = "";
-            if ($bean->field_name_map[$field] != NULL)
+            if (array_key_exists($field, $bean->field_name_map) && !empty($bean->field_name_map[$field]))
             {
               if (array_key_exists("source", $bean->field_name_map[$field]) && $bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
               else if (!empty($bean->field_defs[$field])) $tableName = $bean->getTableName();

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -51,7 +51,14 @@ class Filter
             if ($bean->field_name_map[$field] != NULL)
             {
               if ($bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
-              else $tableName = $bean->getTableName();
+              elseif !(empty($bean->field_defs[$field])) $tableName = $bean->getTableName();
+              else {
+                throw new \InvalidArgumentException(sprintf(
+                    'Filter field %s in %s module is not found',
+                    $field,
+                    $bean->getObjectName()
+                ));
+              }
             } else {
                 throw new \InvalidArgumentException(sprintf(
                     'Filter field %s in %s module is not found',

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -51,7 +51,7 @@ class Filter
             if ($bean->field_name_map[$field] != NULL)
             {
               if ($bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
-              elseif !(empty($bean->field_defs[$field])) $tableName = $bean->getTableName();
+              else if (!empty($bean->field_defs[$field])) $tableName = $bean->getTableName();
               else {
                 throw new \InvalidArgumentException(sprintf(
                     'Filter field %s in %s module is not found',

--- a/Api/V8/JsonApi/Repository/Filter.php
+++ b/Api/V8/JsonApi/Repository/Filter.php
@@ -50,7 +50,7 @@ class Filter
             $tableName = "";
             if ($bean->field_name_map[$field] != NULL)
             {
-              if ($bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
+              if (array_key_exists("source", $bean->field_name_map[$field]) && $bean->field_name_map[$field]["source"] == "custom_fields") $tableName = $bean->getTableName() . "_cstm";
               else if (!empty($bean->field_defs[$field])) $tableName = $bean->getTableName();
               else {
                 throw new \InvalidArgumentException(sprintf(

--- a/Api/V8/Param/Options/Fields.php
+++ b/Api/V8/Param/Options/Fields.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Fields extends BaseOption
 {
-    const REGEX_FIELD_PATTERN = '/[^\w\-,]/';
+    const REGEX_FIELD_PATTERN = '/[^\w !#\$%&\'*+-=?^_`{|}~@.[]]/';
 
     /**
      * @inheritdoc

--- a/Api/V8/Service/RelationshipService.php
+++ b/Api/V8/Service/RelationshipService.php
@@ -67,6 +67,7 @@ class RelationshipService
                 $linkResponse->setSelf(sprintf('V8/module/%s/%s', $relatedBean->getObjectName(), $relatedBean->id));
 
                 $dataResponse = new DataResponse($relatedBean->getObjectName(), $relatedBean->id);
+                $dataResponse->setAttributes($this->attributeHelper->getAttributes($relatedBean, null));
                 $dataResponse->setLinks($linkResponse);
                 $data[] = $dataResponse;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
This is my first time attempting a GIT pull request. Please be gentle!

I've been working with the API for a few months trying to set up a website, and have encountered a few issues that have blocked me from making progress.

Firstly, I found with my created custom fields I was unable to use the API filtering as I would receive a 'Filter field %s in %s module is not found' error due to the API not looking for custom fields in the _cstm tables. I would also see an error in the suitecrm.log from the BeanManager countRecords function as the _cstm table was not being used.

Secondly, I found the REGEX rule to be far too stringent. If a user put an email address in it was stripped out due to the REGEX rule.

Thirdly, I found when getting a Bean relationship the attributes of the related Bean were not included. Whilst it's possible to do a second API request to pull the related bean directly to get the attributes I've found it far easier to just return the attributes of the related bean during the relationship call. I think this makes sense as if you're trying to get hold of the related bean then it's very likely you also want the related beans content, and this saves doing the second API call.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix custom field usage.
Allow more types of character to be used in fields.
Add attributes directly to the related bean.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
For the custom fields change call the API filter function using one of your custom fields. e.g. (where username_c is a custom field):
```
    $request_url = 'http://{suitecrm_domain}/Api/V8/module/Contact?fields[Contact]=id,account_id,username_c,first_name,deleted&filter[operator]=and&filter[username_c][eq]=testuser';
    $ch = curl_init();
    curl_setopt($ch, CURLOPT_URL, $request_url);
    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
      'Content-type: application/vnd.api+json',
      'Accept: application/vnd.api+json',
      'authorization: Bearer {token}'
    ););
    $output = curl_exec($ch);
    curl_close($ch);
```

Code for saving an email address with the new REGEX rule would look something like this:
```
    $request_url = 'http://{suitecrm_domain}/Api/V8/module';
    $post_data = json_encode(array(
      "data" => array(
        "type" => 'EmailAddress',
        "id" => {email_bean_id},
        "attributes" => array('email_address' => 'test@test.com', 'email_address_caps' => 'TEST@TEST.COM')
      )
    ));
    $ch = curl_init();
    curl_setopt($ch, CURLOPT_URL, $request_url);
    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
    curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
      'Content-type: application/vnd.api+json',
      'Accept: application/vnd.api+json',
      'authorization: Bearer {token}'
    ););
    $output = curl_exec($ch);
    curl_close($ch);

```

Code for getting a relationship would look something like this:
```
    $request_url = 'http://{suitecrm_domain}/Api/V8/module/Opportunity/{opportunity_id}/relationships/contacts';
    $ch = curl_init();
    curl_setopt($ch, CURLOPT_URL, $request_url);
    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
      'Content-type: application/vnd.api+json',
      'Accept: application/vnd.api+json',
      'authorization: Bearer {token}'
    ););
    $output = curl_exec($ch);
    curl_close($ch);  
``` 

The key difference being the result will return the attributes:

`{ "data": [ { "type": "Contact", "id": "{contact_id}", "attributes": { "name": "Bob Test", "date_entered": "2020-06-18T18:16:00+00:00", "date_modified": "2020-06-20T10:35:00+00:00" ...`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->