### PR TITLE
Email with bad utf8 encoding caracters

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -555,7 +555,7 @@ class SugarFolder
             $temp['flagged']   = (is_null($a['flagged']) || $a['flagged'] == '0') ? '' : 1;
             $temp['status']    = (is_null($a['reply_to_status']) || $a['reply_to_status'] == '0') ? '' : 1;
             $temp['from']      = preg_replace('/[\x00-\x08\x0B-\x1F]/', '', $a['from_addr']);
-            $temp['subject']   = $a['name'];
+            $temp['subject']   =  htmlentities( $a['name'], ENT_QUOTES, 'utf-8', FALSE);
             $temp['date']      = $this->timeDate->to_display_date_time($this->db->fromConvert($a['date_sent_received'], 'datetime'));
             $temp['uid']       = $a['id'];
             $temp['mbox']      = 'sugar::' . $a['polymorphic_module'];


### PR DESCRIPTION
Email with bad utf8 encoding caracters, can block json_encode function, data error is display in mail list but not error displayed. Replace bad char by htmlentities correct this problem.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Received mail with bad encoding subject. When click in mail folder get "Data Error"

## How To Test This
Send mail with bad encoding caracteres: "��vplsi.com is holding 4 undelivered incoming messages"

Or my example :
```
<?PHP
$name = pack("H*" ,'c32e') . "Hello world" ;
//$name = htmlentities( (string) $value, ENT_QUOTES, 'utf-8', FALSE); //Correction ok
$arr = array(
	"key" => array (
		"a" => $name,
		"b" => "Hello world",
	)
);
print(json_encode($arr));
```
See [](https://stackoverflow.com/a/15519853), Maybe in php 7.2.0 we can use  JSON_INVALID_UTF8_IGNORE, not my case.

## Types of changes
- Bug Fix Mail with bad encoding caracters
