### PR TITLE
Fixed #6771 - Invalid charset conversion for Elasticsearch

### DIFF
--- a/lib/Search/SearchQuery.php
+++ b/lib/Search/SearchQuery.php
@@ -288,7 +288,7 @@ class SearchQuery implements \JsonSerializable
      */
     public function convertEncoding()
     {
-        $this->query = mb_convert_encoding($this->query, 'UTF-8', 'HTML-ENTITIES');
+        $this->query = htmlspecialchars_decode(htmlentities($this->query, ENT_COMPAT, 'utf-8', false));
     }
 
     /** @inheritdoc */

--- a/lib/Utility/ArrayMapper.php
+++ b/lib/Utility/ArrayMapper.php
@@ -409,7 +409,7 @@ class ArrayMapper
     private function fixStringValue($value)
     {
         if (is_string($value)) {
-            $value = mb_convert_encoding($value, 'UTF-8', 'HTML-ENTITIES');
+            $value = htmlspecialchars_decode(htmlentities($value, ENT_COMPAT, 'utf-8', false));
             $value = trim($value);
         }
         return $value;


### PR DESCRIPTION
## Description
Fix non English search with Elasticsearch

https://github.com/salesagility/SuiteCRM/issues/6771

## Motivation and Context
Allow search in non English language

## How To Test This
Use global search with non English text

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->