### PR TITLE
Update HtmlSanitizer.php

### DIFF
--- a/include/HtmlSanitizer.php
+++ b/include/HtmlSanitizer.php
@@ -42,6 +42,7 @@ class HtmlSanitizer
         $config->set('Core.HiddenElements', $hidden_tags);
         $config->set('Cache.SerializerPath', sugar_cached("htmlclean"));
         $config->set('URI.Base', isset($sugar_config['site_url']) ? $sugar_config['site_url'] : null);
+        $config->set('URI.AllowedSchemes', array('http' => true, 'https' => true, 'mailto' => true, 'data' => true, 'tel' => true));
         $config->set('CSS.Proprietary', true);
         $config->set('HTML.TidyLevel', 'light');
         $config->set('HTML.ForbiddenElements', array('body' => true, 'html' => true));


### PR DESCRIPTION
HTMP Purifier by default does not allow `data` URIs in emails and gets stripped out before send.
This is actually a useful tag so you can embed images directly within email templates for headers etc which we use.


Note. when using `email2Send` directly, it does not do `SugarCleaner::cleanHtml` which instead is only applied to emails saved to the DB first.

Should be backported to 7.10.x as well