### PR TITLE
Fixed #9620 - API V8 Token Expiration DateTime isn't stored in UTC

### DIFF
--- a/Api/V8/OAuth2/Repository/AccessTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/AccessTokenRepository.php
@@ -28,6 +28,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     /**
      * @param AccessTokenEntity $accessTokenEntity
      * @param BeanManager $beanManager
+     *
      */
     public function __construct(AccessTokenEntity $accessTokenEntity, BeanManager $beanManager)
     {

--- a/Api/V8/OAuth2/Repository/AccessTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/AccessTokenRepository.php
@@ -80,7 +80,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
         $token->access_token = $accessTokenEntity->getIdentifier();
 
-        $token->access_token_expires = $accessTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
+        $token->access_token_expires = $accessTokenEntity->getExpiryDateTime()->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
 
         $token->client = $clientId;
 

--- a/Api/V8/OAuth2/Repository/AccessTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/AccessTokenRepository.php
@@ -5,6 +5,7 @@ namespace Api\V8\OAuth2\Repository;
 use Api\V8\BeanDecorator\BeanManager;
 use Api\V8\OAuth2\Entity\AccessTokenEntity;
 use DateTime;
+use DateTimeZone;
 use InvalidArgumentException;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;

--- a/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
@@ -1,6 +1,7 @@
 <?php
 namespace Api\V8\OAuth2\Repository;
 
+use DateTimeZone;
 use Api\V8\BeanDecorator\BeanManager;
 use Api\V8\OAuth2\Entity\RefreshTokenEntity;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;

--- a/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
+++ b/Api/V8/OAuth2/Repository/RefreshTokenRepository.php
@@ -47,7 +47,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         }
 
         $token->refresh_token = $refreshTokenEntity->getIdentifier();
-        $token->refresh_token_expires = $refreshTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
+        $token->refresh_token_expires = $refreshTokenEntity->getExpiryDateTime()->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
         $token->save();
     }
 


### PR DESCRIPTION
Made the fix to issue #9260 by formatting the Token Expiration DateTime object for both Refresh and Access Tokens.

## How To Test This
To Test, simply request a token and then check database to be sure it is stored in UTC.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)

### Final checklist
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.