### PR TITLE
Fix #9463 - Avoid sending multiple forms

### DIFF
--- a/modules/Campaigns/WebToLeadFormBuilder.php
+++ b/modules/Campaigns/WebToLeadFormBuilder.php
@@ -115,6 +115,22 @@ HTML;
         $html = <<<HTML
 </form>
 <script type='text/javascript'>
+    var formHasAlreadyBeenSent = false;
+    /**
+     * Prevent multiple form submissions
+     *
+     * @return void
+     */
+    function lockMultipleSubmissions() {
+        if (formHasAlreadyBeenSent) {
+            console.log("Form is locked because it has already been sent.");
+            event.preventDefault();
+        }
+        formHasAlreadyBeenSent = true;
+    }
+    // Attach function to event
+    document.getElementById("WebToLeadForm").addEventListener("submit", lockMultipleSubmissions);
+
     function submit_form() {
         if (typeof(validateCaptchaAndSubmit) != 'undefined') {
             validateCaptchaAndSubmit();


### PR DESCRIPTION
Closes #9463

## Description
As described in the the Issue, there isn't a mechanism that will lock the form after the first submission. Letting the user click repeatedly in the submit button and sending several forms.

This PR introduces a mechanism to the form wizard that includes a JS code to lock the form once it was submitted for the first time.

## Motivation and Context
With this addition, user's won't be able to send duplicate forms.

## How To Test This
1. Create a WebToLeadForm
2. Fill the form
3. Click in submit several times
4. Check in the CRM that only one Lead is created

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.