### PR TITLE
Fixed quick search field check to mirror logic for SearchForm view

### DIFF
--- a/include/TemplateHandler/TemplateHandler.php
+++ b/include/TemplateHandler/TemplateHandler.php
@@ -551,10 +551,11 @@ class TemplateHandler
                 $name = $qsd->form_name . '_' . $field['name'];
 
 
-                if ($field['type'] === 'relate' && isset($field['module']) && (preg_match(
-                    '/_name$|_c$/si',
-                    $name
-                ) || !empty($field['quicksearch']))
+                if (($field['type'] === 'relate' &&
+                        isset($field['module']) &&
+                        !empty($field['module']) &&
+                        preg_match('/_name$|_c$/si', $name)) ||
+                    !empty($field['quicksearch'])
                 ) {
                     if (!preg_match('/_c$/si', $name)
                         && (!isset($field['id_name']) || !preg_match('/_c$/si', $field['id_name']))


### PR DESCRIPTION
Just changing the logic on the other side of this conditional so that in an EditView a custom field which has quicksearch => "true" gets quicksearch functionality even if it isn't a "relate" field. This is the same change as [here](https://github.com/salesagility/SuiteCRM/commit/a708b6441c7d47e41cea2dc3fc56b697fea5952c), but just making sure that it  applies to all views, not just SearchForm.

## Motivation and Context
Quick Search functionality should be available to any field, not just relate fields.
## How To Test This
1. Create a custom field type and give it autocomplete ability using sqs_objects
2. Create a custom field of this new custom type under any module
3. Add the custom field to the edit view of the module
4. Assign the field a module => 'Users' and quicksearch => true in the vardef file
5. Load the editView and click into the field and type, it should now autocomplete from the module specified.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.