### PR TITLE
Fix #9619 - Surveys - Deleting records from related modules in cascade

### DIFF
--- a/modules/SurveyQuestions/SurveyQuestions.php
+++ b/modules/SurveyQuestions/SurveyQuestions.php
@@ -79,4 +79,13 @@ class SurveyQuestions extends Basic
 
         return false;
     }
+
+    public function mark_deleted($id)
+    {
+        $optionQuestionBeans = $this->get_linked_beans('surveyquestions_surveyquestionoptions');
+        foreach ($optionQuestionBeans as $optionQuestionBean) {
+            $optionQuestionBean->mark_deleted($optionQuestionBean->id);
+        }
+        parent::mark_deleted($id);
+    }
 }

--- a/modules/SurveyResponses/SurveyResponses.php
+++ b/modules/SurveyResponses/SurveyResponses.php
@@ -224,4 +224,14 @@ class SurveyResponses extends Basic
         $emailObj->status = 'sent';
         $emailObj->save();
     }
+
+    public function mark_deleted($id)
+    {
+        $questionResponsesBeans = $this->get_linked_beans('surveyresponses_surveyquestionresponses');
+        foreach ($questionResponsesBeans as $questionResponsesBean) {
+            $questionResponsesBean->mark_deleted($questionResponsesBean->id);
+        }
+
+        parent::mark_deleted($id);
+    }
 }

--- a/modules/Surveys/tpls/editsurveyquestions.tpl
+++ b/modules/Surveys/tpls/editsurveyquestions.tpl
@@ -49,9 +49,9 @@
       var questionIndex = target.data('question-index');
       var list = target.closest('td').find('ul');
       var html = "<li>"
-        + "<input type='hidden' class='survey_question_options_id' name='survey_questions_options_id[" + questionIndex + "][]'/>"
-        + "<input type='hidden' class='survey_question_options_deleted' name='survey_questions_options_deleted[" + questionIndex + "][]' value='0'/>"
-        + "<input class='survey_question_options' name='survey_questions_options[" + questionIndex + "][]' type='text'/>"
+        + "<input type='hidden' class='survey_question_options_id' name='survey_question_options_id[" + questionIndex + "][]'/>"
+        + "<input type='hidden' class='survey_question_options_deleted' name='survey_question_options_deleted[" + questionIndex + "][]' value='0'/>"
+        + "<input class='survey_question_options' name='survey_question_options[" + questionIndex + "][]' type='text'/>"
         + "<button type='button' class='button deleteQuestionOption'><span class='suitepicon suitepicon-action-clear'></span></button>"
         + "</li>";
       var item = $(html);


### PR DESCRIPTION
- Closes #9619 

## Description
As described by the issue, this PR implements the proposed changes overriding the function mark_deleted for each Bean and fixing some array key syntax mistakes survey_question**s**_options => survey_question_options

## Motivation and Context
This should maintain the database tables cleaner

## How To Test This
Test each of the conditions mentioned in the Issue:
Modules involved:
1 - Surveys (It can be accessed from the UI)
2 - SurveyQuestions
3 - SurveyQuestionOptions
4 - SurveyResponses (It can be accessed from the UI)
5 - SurveyQuestionResponses

When deleting a record from a module, they should be deleted in cascade the records from the next modules:
- If we delete records from the module 1, the related records from the modules 2 and 3 should be deleted in cascade, but only if the surveys deleted don't have any related answer
- if we delete records from the module 2, the related records from the module 3 should be deleted (this can only happen if the Survey wasn't publish public)
- If we delete records from the module 4, the related records from the module 5 should be deleted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->