### PR TITLE
Core fix - Sets correct body when editing a Draft email.

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -1874,7 +1874,12 @@ class Email extends Basic
         $r = $this->db->query($q);
         $a = $this->db->fetchByAssoc($r, false);
 
-        $this->description = $a['description'];
+        // BUG FIX - Fixes bug where draft editor would use incorrect version of the email body, losing formatting.
+        if ($this->status === 'draft') {
+            $this->description = $a['description_html'];
+        } else {
+            $this->description = $a['description'];
+        }
         $this->description_html = $a['description_html'];
         $this->raw_source = $a['raw_source'];
         $this->from_addr_name = $a['from_addr'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Correctly sets the body in the HTML Editor field when editing a Draft email so that it uses the `description_html` data, avoiding loss of formatting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Stops the loss of formatting when editing an In Draft Email.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create Draft email with some formatting (headers, bold etc.)
2. Save draft and reopen draft email in edit view.
3. Check that the formatting is kept.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->