### PR TITLE
Update Folders to Mark Group Folders =1 RE: #9028

### DIFF
--- a/include/SugarFolders/SugarFolders.php
+++ b/include/SugarFolders/SugarFolders.php
@@ -1268,7 +1268,23 @@ class SugarFolder
     public function save($addSubscriptions = true)
     {
         $this->dynamic_query = $this->db->quote($this->dynamic_query);
+        //Fix to mark group folders with is_group =1
+        //retreive value of is_personal for the current folder
+        //check current folder is a parent folder
+        if (!empty($this->parent_folder)) {
+            $query2 = "SELECT is_personal FROM inbound_email WHERE id = " . $this->db->quoted($this->parent_folder);
+        } else {
+            $query2 = "SELECT is_personal FROM inbound_email WHERE id = " . $this->db->quoted($this->id);
+        }
 
+        $r2 = $this->db->query($query2);
+        $is_personal = $this->db->fetchByAssoc($r2)['is_personal'];
+        // Set the value of `is_group` based on the value of `is_personal`
+        if ($is_personal == 1) {
+            $is_group = 0;
+        } else {
+            $is_group = 1;
+        }
         if ((!empty($this->id) && $this->new_with_id == false) || (empty($this->id) && $this->new_with_id == true)) {
             if (empty($this->id) && $this->new_with_id == true) {
                 $guid = create_guid();
@@ -1282,7 +1298,7 @@ class SugarFolder
                     $this->db->quoted($this->folder_type) . ", " .
                     $this->db->quoted($this->parent_folder) . ", " .
                     $this->db->quoted($this->has_child) . ", " .
-                    $this->db->quoted($this->is_group) . ", " .
+                    $this->db->quoted($is_group) . ", " . // set the value of is_group here
                     $this->db->quoted($this->is_dynamic) . ", " .
                     $this->db->quoted($this->dynamic_query) . ", " .
                     $this->db->quoted($this->assign_to_id) . ", " .
@@ -1305,7 +1321,8 @@ class SugarFolder
                 "parent_folder = " . $this->db->quoted($this->parent_folder) . ", " .
                 "dynamic_query = " . $this->db->quoted($this->dynamic_query) . ", " .
                 "assign_to_id = " . $this->db->quoted($this->assign_to_id) . ", " .
-                "modified_by = " . $this->db->quoted($this->currentUser->id) . " " .
+                "modified_by = " . $this->db->quoted($this->currentUser->id) . "," .
+                "is_group = " . $is_group . " " .
                 "WHERE id = " . $this->db->quoted($this->id);
         }
 


### PR DESCRIPTION
This is a fix so that when an Inbound email account is created or edited, the folder gets updated with is_group =1 if it is a group folder.  This is necessary because only group folders with is_group=1 show up for users to view (if they have access) in email ListView when switching between folders.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
The changes check to see if the current folder being updated (after a change or Inbound Account creation) is a parent folder or not.  If a parent folder, it checks to via the ID of the folder to see if the associated Inbound account is a "group" account.  If so, it marks the parent folder with is_group =1.

If it is not a parent folder, then it uses the parent folder ID to lookup the associated Inbound Account and whether or not it is  a group account.  If it is a group account, it marks the folder with is_group=1.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
This is to address https://github.com/salesagility/SuiteCRM/issues/9028

<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently only admins can see group folders.  The filter that makes folders available for viewing on the front end selects only folders that is_group=1 or is created by the user.  (unless the user is admin and then it shows all).  This will allow folder to be marked accordingly so that they can be seen by users (and they are subscribed to the folder).

## How To Test This
<!--- Please describe in detail how to test your changes. -->
This change is needed in conjunction with:  https://github.com/salesagility/SuiteCRM/pull/8702
And hotfix:  https://github.com/salesagility/SuiteCRM/pull/8702/commits/5132dc54f7199f8f60ee510183a2f8320325eb8b
pull #8702 is also a problem because it has a syntax error.  Once 8702 is applied along with this hotfix users will be able to see group folders in Inbound Email ListView when clicking on the folders button to switch folders.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->