### PR TITLE
Fix 10136- Total Sum is defaulting to type hidden due to missing brea…

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -974,7 +974,8 @@ class AOR_Report extends Basic
                             $total,
                             '',
                             $currency->id,
-                            $params
+                            $params,
+                            true
                         );
                         break;
                     case 'COUNT':

--- a/modules/AOW_WorkFlow/aow_utils.php
+++ b/modules/AOW_WorkFlow/aow_utils.php
@@ -319,7 +319,8 @@ function getModuleField(
     $value = '',
     $alt_type = '',
     $currency_id = '',
-    $params= array()
+    $params= array(),
+    $usedInTotal = false
 ) {
     global $current_language;
     global $app_strings;
@@ -389,6 +390,10 @@ function getModuleField(
         }
 
         //$vardef['precision'] = $locale->getPrecedentPreference('default_currency_significant_digits', $current_user);
+
+        if ($vardef['type'] == 'enum' && $usedInTotal) {
+            $vardef['type'] = 'text';
+        }
 
         if ($vardef['type'] == 'datetime') {
             $vardef['type'] = 'datetimecombo';


### PR DESCRIPTION
Fix 10136- Total Sum is defaulting to type hidden due to missing break in swtich case.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
Resolves the issue described in [Issue-10136](https://github.com/salesagility/SuiteCRM/issues/10136)

## How To Test This
1.Create a report using AOR_Report.
2.For one of the fields select sum total.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->