### PR TITLE
Fix #10170 - Call/Meeting Reminders - Can lock out user from any action besides F5

### DIFF
--- a/modules/Reminders/Reminders.js
+++ b/modules/Reminders/Reminders.js
@@ -169,6 +169,7 @@ var Reminders = {
 
     addReminder: function(e, popup, email, timer_popup, timer_email, reminderId, invitees) {
         if(!reminderId) reminderId = '';
+        let reminderIdX = Reminders.getRemindersData().length;
         Reminders.setReminderPopupChkbox($('#reminder_template'), popup);
         Reminders.setReminderEmailChkbox($('#reminder_template'), email);
         Reminders.setPopupTimerSelectValue($('#reminder_template'), timer_popup);
@@ -179,7 +180,7 @@ var Reminders = {
         else {
             Reminders.addInvitees(e, invitees);
         }
-        $('#reminder_view').append('<li class="reminder_item" data-reminder-id="' + reminderId + '">' + $('#reminder_template').html() + '</li>');
+        $('#reminder_view').append('<li class="reminder_item" data-reminder-id="' + reminderId + '" data-reminder-idx="' + reminderIdX + '">' + $('#reminder_template').html() + '</li>');
     },
 
     onAddClick: function(e){
@@ -197,10 +198,11 @@ var Reminders = {
     onInviteeClick: function(e) {
         var parentReminderItem = $(e).closest('.reminder_item');
         var parentReminderId = parentReminderItem.attr('data-reminder-id');
+        var parentReminderIdX = parentReminderItem.attr('data-reminder-idx');
         var reminders = Reminders.getRemindersData();
         var _e = e;
         $.each(reminders, function(i, reminder) {
-            if(reminder.id == parentReminderId && reminder.invitees.length == 1) {
+            if((reminder.id != '' && reminder.id == parentReminderId || i == parentReminderIdX) && reminder.invitees.length == 1) {
                 var confirmDeletePopup = new YAHOO.widget.SimpleDialog("Confirm ", {
                     //width: "400px",
                     draggable: false,

--- a/modules/Reminders/tpls/reminders.tpl
+++ b/modules/Reminders/tpls/reminders.tpl
@@ -165,7 +165,7 @@
 
         {foreach from=$remindersData item=reminder}
 
-            <ul class="reminder_item" data-reminder-id="{$reminder.id}">
+            <ul class="reminder_item" data-reminder-id="{$reminder.id}" data-reminder-idx="{$reminder.idx}">
 
                 <span class="error-msg"></span>
 


### PR DESCRIPTION
Fix for issue with mask overlay not disappearing in create-view

## Description
Fix for issue [10170](https://github.com/salesagility/SuiteCRM/issues/10170). The problem is caused by the code that displays the confirmation alert for removing "remindee" being unable to identify the correct Reminder-object to show the confirmation for when there are several new reminders added at once. 
This makes it open a Confirm-dialog for each and every _new_ reminder being added, causing issues when the cancel-button is clicked.

My fix involves using an iterative client-side id that is independent of missing suitecrm-id's when they are missing for new records.

## Motivation and Context
This fix solves a GUI issue that improves the user experience.

## How To Test This

1. Call / Meeting -> Open Create Call or Meeting.
2. Add two reminders.
3. Remove a user from one of the reminders and get prompt message to which you press Cancel.

Prior to this fix the background overlay would stay in place, blocking all elements. After applying this fix the overlay is cleared when clicking cancel.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

