### PR TITLE
Fix #10511 - make correct redirect to Opportunity's DetailView without extra data from submitted form

### DIFF
--- a/modules/Contacts/ContactOpportunityRelationshipEdit.html
+++ b/modules/Contacts/ContactOpportunityRelationshipEdit.html
@@ -60,7 +60,7 @@
 	<input id="cancel_btn_48516" type="submit" name="button" class="button"
 		title="{APP.LBL_CANCEL_BUTTON_TITLE}"
 		accessKey="{APP.LBL_CANCEL_BUTTON_KEY}"
-		onclick="this.form.action.value='{RETURN_ACTION}'; this.form.module.value='{RETURN_MODULE}'; this.form.record.value='{RETURN_ID}'"
+		onclick="window.location.href='index.php?module={RETURN_MODULE}&action={RETURN_ACTION}&record={RETURN_ID}';return false;"
 		value="  {APP.LBL_CANCEL_BUTTON_LABEL}  "
 	/>
 </td>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

Fixed issue #10511.

## Description
Issue happens because user not redirected to other page but submitting form on "Contact-Opportunity" page with other form data that should send at request. And this data wrongly adds to search queries because `SubPanel` class uses `SeacrhForm` functionality to filter data and `SearchForm` grubs data from `$_POST` that should happens for subpanels. Thats why it includes `contact_name` and `contact_id` to SQL that doesn't include this tables and shouldn't filter by these params. 
Example of wrongly generated SQL:
```sql
SELECT count(*) c FROM meetings  LEFT JOIN meetings_cstm ON meetings.id = meetings_cstm.id_c  INNER JOIN  opportunities meetings_rel ON meetings.parent_id=meetings_rel.id AND meetings_rel.deleted=0
 AND meetings.parent_type = 'Opportunities'
 where ( meetings.parent_id='37f91d5123-4123b-1e77-c115-66ba1b2a814c' AND (meetings.status !='Held' AND meetings.status !='Not Held') AND (( contacts.first_name like 'John23 test%' OR contacts.last_name like 'John23 test%' ))) AND meetings.deleted=0 )  
```

## Steps to reproduce issue
1. Open DetailView of some Opportunity that has linked Contact at subpanel
2. Expand 'Contacts', 'History' and 'Activities' subpanels
3. Click 'Edit' on Contact at subpanel
4. It opens custom page to manage role of the Contact at Opportunity
5. Click "Cancel"
6. It returns to Opportunity's DetailView 

[ER]: all subpanels works fine without errors and print linked data
[AR]: have message at some subpanels "Database failure. Please refer to suitecrm.log for details."
![image](https://github.com/user-attachments/assets/653ef243-54ef-4ebc-ad1c-2351521a23f9)


## Motivation and Context
This bug breaks business logic at out company. Extra data from "Contact-Opportunity" form should send to Opportunity's DetailView page.
This PR fixed issue with broken subpanels on Opportunity DetailView, one of the most common modules.

## How To Test This
Open "Contact-Opportunity" page from Contacts subpanel and click "Cancel".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->