### PR TITLE
Fix #10570 - Email Signature Compose View Issues

### DIFF
--- a/modules/Emails/EmailsDataAddressCollector.php
+++ b/modules/Emails/EmailsDataAddressCollector.php
@@ -493,7 +493,8 @@ class EmailsDataAddressCollector
         );
         $dataAddressesWithUserAddressesAndSystem = $this->fillDataAddressWithSystemMailerSettings(
             $dataAddressesWithUserAddresses,
-            $defaultEmailSignature
+            $defaultEmailSignature,
+            $prependSignature
         );
 
         return
@@ -661,9 +662,10 @@ class EmailsDataAddressCollector
      *
      * @param array $dataAddresses
      * @param array $defaultEmailSignature
+     * @param boolean $prependSignature
      * @return array
      */
-    protected function fillDataAddressWithSystemMailerSettings($dataAddresses, $defaultEmailSignature)
+    protected function fillDataAddressWithSystemMailerSettings($dataAddresses, $defaultEmailSignature, $prependSignature)
     {
         $this->setOe(new OutboundEmail());
         if ($this->getOe()->isAllowUserAccessToSystemDefaultOutbound()) {
@@ -674,7 +676,8 @@ class EmailsDataAddressCollector
                 $system->smtp_from_name,
                 $system->smtp_from_addr,
                 $system->mail_smtpuser,
-                $defaultEmailSignature
+                $defaultEmailSignature,
+                $prependSignature
             );
         }
 
@@ -744,6 +747,7 @@ class EmailsDataAddressCollector
      * @param string $fromAddr
      * @param string $mailUser
      * @param array $defaultEmailSignature
+     * @param boolean $prependSignature
      * @return array
      */
     protected function getFillDataAddressArray(
@@ -752,7 +756,8 @@ class EmailsDataAddressCollector
         $fromName,
         $fromAddr,
         $mailUser,
-        $defaultEmailSignature
+        $defaultEmailSignature,
+        bool $prependSignature = false
     ) {
         $dataAddress = new EmailsDataAddress();
 
@@ -763,7 +768,7 @@ class EmailsDataAddressCollector
             $fromAddr,
             $fromName,
             false,
-            false,
+            $prependSignature,
             true,
             $id,
             $name,

--- a/modules/Emails/include/ComposeView/EmailsComposeView.js
+++ b/modules/Emails/include/ComposeView/EmailsComposeView.js
@@ -60,6 +60,12 @@
     self.prependSignature = false;
 
     /**
+     * Determines if a Signature has already been added to the message
+     * @type {boolean}
+     */
+    self.signatureAdded = false;
+
+    /**
      * Defines the buttons that are displayed when the user focuses in on a to, cc and bcc field.
      *
      * @param data-open-popup-module - The module to popup
@@ -348,6 +354,18 @@
       return false;
     };
 
+    /**
+     * Remove any existing signature element class in the email thread
+     * @type {self.removeExistingSignatureClass}
+     */
+
+    $.fn.EmailsComposeView.removeExistingSignatureClass = self.removeExistingSignatureClass = function() {
+      let body = tinymce.activeEditor.getContent();
+      let $body = $('<div>').append($(body));
+      let $signatureElement = $body.find('div.email-signature-element');
+      $signatureElement.removeClass('email-signature-element');
+      tinymce.activeEditor.setContent($body.html(), {format: 'html'})
+    }
 
     $.fn.EmailsComposeView.updateSignature = self.updateSignature = function ($selected) {
       if(!$selected) {
@@ -362,9 +380,13 @@
 
       var body = tinymce.activeEditor.getContent();
       if (body !== '' && $(body).hasClass('email-signature-element')) {
-        var $body = $(body);
-        var $existingSignature = $body.find('.email-signature-element');
-        $existingSignature.remove();
+        var $body = $('<div>').append($(body));
+        var $existingSignature = $body.find('div.email-signature-element');
+        if(self.prependSignature) {
+          $existingSignature.outerText = '';
+        } else {
+          $existingSignature.remove();
+        }
         tinymce.activeEditor.setContent($body.html(), {format: 'html'});
       }
 
@@ -1301,11 +1323,16 @@
             $(self).trigger('emailComposeViewGetFromFields');
 
 
-            if (tinymce.initialized === true) {
+            if (tinymce.initialized === true && !self.signatureAdded) {
+              self.removeExistingSignatureClass();
               self.updateSignature();
-            } else if(tinymce.EditorManager && tinymce.EditorManager.activeEditor) {
+              self.signatureAdded = true;
+            } else if(tinymce.EditorManager && tinymce.EditorManager.activeEditor && !self.signatureAdded) {
               tinymce.EditorManager.activeEditor.on('init', function(e) {
+                self.removeExistingSignatureClass();
                 self.updateSignature();
+                self.signatureAdded = true;
+
               });
             }
           }
@@ -1357,11 +1384,13 @@
 
         var intervalCheckTinymce = window.setInterval(function () {
           var isFromPopulated = $('#from_addr_name').prop("tagName").toLowerCase() === 'select';
-          if (tinymce.editors.length > 0 && isFromPopulated === true) {
+          if (tinymce.editors.length > 0 && isFromPopulated === true && !self.signatureAdded) {
+            self.removeExistingSignatureClass();
             self.updateSignature();
+            self.signatureAdded = true;
             clearInterval(intervalCheckTinymce);
           }
-        }, 300);
+        }, 750);
 
         tinymce.init(opts.tinyMceOptions);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Email signatures will sometimes remove the email thread when replying to an email. 

Email signatures elements that are on an email thread will also be replaced by the users email signature.

Email signatures will occasionally not be added to the email if the From fields have not been fully loaded in.

From fields can fail to load due to php82 fatal errors

```
PHP Fatal error:  Uncaught TypeError: EmailsDataAddressCollector::getFillDataAddressArray(): Argument #7 ($prependSignature) must be of type bool, null given, called in /var/www/SuiteCRM/modules/Emails/EmailsDataAddressCollector.php on line 673 and defined in /var/www/SuiteCRM/modules/Emails/EmailsDataAddressCollector.php:753

PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, bool given in /var/www/SuiteCRM/modules/Emails/EmailsDataAddressCollector.php:151
```

Includes fixes proposed by @JackBuchanan in https://github.com/salesagility/SuiteCRM/pull/9746

## Motivation and Context
Email is an integral part of the CRM system and these inconsistencies are causing issues using the Email module for sending emails. This should provide consistency in how emails are loaded on the Compose and reply to views. Additional improvements could be made once this consistency is established.

## How To Test This
1. Set up an email signature on the user profile
2. Import an email to reply to
3. Open the email and choose Reply To
4. See that occasionally the email thread will be deleted, the email signature will not be loaded, and previous email signature elements can be replaced by the users current email signature(even if other SuiteCRM users are in the thread)

Alternative for non-thread related issues

1. Set up an email signature on the user profile
2. Navigate to the compose view on the Emails modules
3. Refresh multiple times, occasionally the email signature will not be added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->