### PR TITLE
Fix #10695 - ensure output buffer is flushed prior to pdf generation.

### DIFF
--- a/modules/AOS_PDF_Templates/generatePdf.php
+++ b/modules/AOS_PDF_Templates/generatePdf.php
@@ -138,6 +138,8 @@ $footer = templateParser::parse_template($footer, $object_arr);
 
 $printable = str_replace("\n", "<br />", (string) $converted);
 
+ob_flush(); //Prior to using tcpdf to generate a pdf, the output buffer must be empty.
+
 if ($task === 'pdf' || $task === 'emailpdf') {
     $file_name = $mod_strings['LBL_PDF_NAME'] . "_" . str_replace(" ", "_", (string) $bean->name) . ".pdf";
 


### PR DESCRIPTION
Ensure the output buffer is empty prior to attempting to generate a pdf.

In order to generate a pdf, the output buffer MUST be empty, or else tcpdf shall return an error.


## Description

This commit fixes #10695 , and flushes the active output buffer prior to attempting to generate a pdf.

As noted in the bug report, if tcpdf sees the output buffer is not empty, it will fail with a cryptic error.

## Motivation and Context

This ensures that we do not subsequently fail the ob_get_contents() checks conducted by tcpdf when generating a pdf output.

## How To Test This

This change was tested on our local installation of suiteCRM.

## Types of changes

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [X ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
