### PR TITLE
Fix #10290 where decimal mismatch is reported on quick repair and rebuild

### DIFF
--- a/modules/DynamicFields/templates/Fields/TemplateCurrency.php
+++ b/modules/DynamicFields/templates/Fields/TemplateCurrency.php
@@ -82,6 +82,14 @@ class TemplateCurrency extends TemplateRange
     {
         $def = parent::get_field_def();
         $def['precision'] = (!empty($this->precision)) ? $this->precision : 6;
+
+        // Len attribute correction, now sends the length with precision back for the comparison
+        $newlen = (string) $def['len'];
+        if(preg_match('/^[0-9]+$/', $newlen))
+        {
+            $def['len'] = $newlen.','.$this->precision;
+        }
+
         return $def;
     }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Fix issue #10290 with data mismatch on QRR for decimal fields
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Make decimal field in vardefs have a default of "1.00"
Run Quick Repair and Rebuild

Due to MySQL decimal having precision of 6 e.g. 1.00000 the default in the DB is saved as 1.00000 where as the vardef is 1.00 resulting an a bad comparison on QRR
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->