### PR TITLE
Use Correct alias in Security Group

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3581,7 +3581,7 @@ class SugarBean
             && isset($sugar_config['securitysuite_filter_user_list'])
             && $sugar_config['securitysuite_filter_user_list']
         ) {
-            $groupWhere = SecurityGroup::getGroupUsersWhere($user->id);
+            $groupWhere = SecurityGroup::getGroupUsersWhere($user->id, $this->table_name);
             $conditions['group'] = $groupWhere;
         } elseif ($this->bean_implements('ACL') && ACLController::requireSecurityGroup($this->module_dir, $view)) {
             $ownerWhere = $this->getOwnerWhere($user->id);

--- a/modules/SecurityGroups/SecurityGroup.php
+++ b/modules/SecurityGroups/SecurityGroup.php
@@ -58,15 +58,16 @@ class SecurityGroup extends SecurityGroup_sugar
      * Gets the join statement used for returning all users that a given user is in the same group with.
      *
      * @param string $user_id
+     * @param string $alias By Default `users` for User table, but in case in Reports it is changed that use that
      *
      * @return string
      */
-    public static function getGroupUsersWhere($user_id)
+    public static function getGroupUsersWhere($user_id, $alias = 'users')
     {
         $db = DBManagerFactory::getInstance();
         $quotedUserId = $db->quote($user_id);
 
-        return " users.id in (
+        return " $alias.id in (
             select sec.user_id from securitygroups_users sec
             inner join securitygroups_users secu on sec.securitygroup_id = secu.securitygroup_id and secu.deleted = 0
                 and secu.user_id = '$quotedUserId'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Why is this change required? What problem does it solve? -->
When Security Group setting Filter User List is checked, then a report, which has related User field, does not work due to sql query error.
```
[FATAL]  Query Failed: SELECT `calls:assigned_user_link`.first_name AS 'First_Name0', SUM(`calls`.total_duration) AS 'Total_Minutes1' FROM `calls` LEFT JOIN users `calls:assigned_user_link` ON `calls`.assigned_user_id=`calls:assigned_user_link`.id AND `calls:assigned_user_link`.deleted=0

 AND  users.id in (
            select sec.user_id from securitygroups_users sec
            inner join securitygroups_users secu on sec.securitygroup_id = secu.securitygroup_id and secu.deleted = 0
                and secu.user_id = '********-****-****-****-********'
            where sec.deleted = 0
        ) WHERE ( DATE(`calls`.date_entered) = Curdate() AND `calls`.status = 'Held' ) AND  calls.deleted = 0  GROUP BY `calls:assigned_user_link`.first_name: MySQL error 1054: Unknown column 'users.id' in 'IN/ALL/ANY subquery'
```

https://github.com/SuiteCRM/SuiteCRM/issues/10730

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a Report of Module `Calls`, with field Assigned User and Duration Minutes (use Function Sum)
2. Now Add Bar Chart with Assigned User on X axis and Duration Minutes on Y axis
3. Save and Open this report with Regular user

Chart and Data will appear just like it appears in Admin User

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->