### PR TITLE
feat(API): allow DocumentRevision uploads via V8 JSON API

### DIFF
--- a/Api/V8/Service/ModuleService.php
+++ b/Api/V8/Service/ModuleService.php
@@ -277,6 +277,9 @@ class ModuleService
         if ($fileUpload && $bean->module_dir === 'Notes') {
             $this->addFileToNote($bean->id, $attributes);
         }
+        if ($fileUpload && $bean->module_dir === 'DocumentRevisions') {
+            $this->addFileToDocumentRevision($bean->id, $attributes);
+        }
         if ($fileUpload && $bean->module_dir === 'Documents') {
             $this->addFileToDocument($bean, $attributes);
         }
@@ -367,7 +370,53 @@ class ModuleService
      * @param $attributes
      * @throws Exception
      */
-    protected function addFileToNote($beanId, $attributes)
+    protected function addFileToDocumentRevision($beanId, $attributes)
+    {
+        global $sugar_config, $log;
+
+        $module = 'DocumentRevision';
+        if (!empty($attributes['moduleName'])) {
+            $module = $attributes['moduleName'];
+            unset($attributes['moduleName']);
+     }
+        BeanFactory::unregisterBean($module, $beanId);
+        $bean = $this->beanManager->getBeanSafe($module, $beanId);
+
+        // Write file to upload dir
+        try {
+            // Checking file extension
+            $extPos = strrpos((string) $attributes['filename'], '.');
+            $fileExtension = substr((string) $attributes['filename'], $extPos + 1);
+
+            if ($extPos === false || empty($fileExtension) || in_array(
+                    $fileExtension,
+                    $sugar_config['upload_badext'],
+                    true
+                )) {
+                throw new Exception('File upload failed: File extension is not included or is not valid.');
+            }
+
+            $fileName = $bean->id;
+            $fileContents = $attributes['filecontents'];
+            $targetPath = 'upload/' . $fileName;
+            $content = base64_decode($fileContents);
+
+            $file = fopen($targetPath, 'wb');
+            fwrite($file, $content);
+            fclose($file);
+        } catch (Exception $e) {
+            $log->error('addFileToNote: ' . $e->getMessage());
+            throw new Exception($e->getMessage());
+        }
+
+        // Fill in file details for use with upload checks
+        $mimeType = mime_content_type($targetPath);
+        $bean->filename = $attributes['filename'];
+        $bean->file_mime_type = $mimeType;
+        $bean->save();
+    }
+    
+     protected function addFileToNote($beanId, $attributes)
     {
         global $sugar_config, $log;
 

--- a/modules/DocumentRevisions/vardefs.php
+++ b/modules/DocumentRevisions/vardefs.php
@@ -221,6 +221,13 @@ $dictionary['DocumentRevision'] = array('table' => 'document_revisions'
       'len' => '255',
       'source' => 'non-db',
   ),
+  filecontents' =>
+  array(
+       'name' => 'filecontents',
+       'vname' => 'LBL_FILE_CONTENTS',
+       'type' => 'varchar',
+       'source' => 'non-db',
+  ),
   'latest_revision' =>
   array(
       'name' => 'latest_revision',

--- a/modules/DocumentRevisions/vardefs.php
+++ b/modules/DocumentRevisions/vardefs.php
@@ -221,7 +221,7 @@ $dictionary['DocumentRevision'] = array('table' => 'document_revisions'
       'len' => '255',
       'source' => 'non-db',
   ),
-  filecontents' =>
+  'filecontents' =>
   array(
        'name' => 'filecontents',
        'vname' => 'LBL_FILE_CONTENTS',


### PR DESCRIPTION
## Description
Makes changes to the API to allow for similar functionality from notes to be used within DocumentRevisions.

**Note:** I originally opened this PR a couple of years ago in the wrong repository [#457](https://github.com/SuiteCRM/SuiteCRM-Core/pull/457). Since then, I noticed that some users are currently facing the exact same issue, which motivated me to reopen it here in the correct repository for SuiteCRM 7. Hopefully, this can finally be merged to help the community. @hjdeheer, thanks for the reminder! :)

Based on the changes from this previous pull: [#8910](https://github.com/salesagility/SuiteCRM/pull/8910)

## Motivation and Context
At Innovery, we've faced recurring challenges with the `set_document_revision` SOAP v4 endpoint, which isn't operating as expected within our installation. This pull request addresses the incomplete DocumentRevision endpoint on the V8 JSON API, providing a resolution. With this update, you can seamlessly transition from using the `set_document_revision` from API v4_1 to this solution in JSON V8.

## How To Test This
Using Postman or any client, attempt to POST the following:

**Disclaimer:** Use a `document_id` of an existing document.

```json
{
  "data": {
    "type": "DocumentRevision",
    "attributes": {
      "document_id": "1296d27b-8b58-f1a9-e43e-46f281d3dd4a",
      "change_log": "Document Created test",
      "filename": "test.txt",
      "revision": "2",
      "filecontents": "dGVzdA=="
    }
  }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->