### PR TITLE
Fix typo in timing global

### DIFF
--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -42,7 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$GLOBALS['starttTime'] = microtime(true);
+$GLOBALS['startTime'] = microtime(true);
 
 set_include_path(
     __DIR__.'/..'.PATH_SEPARATOR.


### PR DESCRIPTION
I'm not at all familiar with the code base but glossing through it this seems like a typo since I can't find another occurrence of this variable, but found a couple of references to `$GLOBALS['startTime']`.