### PR TITLE
Fix #10788 - Reports PDF Export Malformed HTML

### DIFF
--- a/modules/AOR_Reports/AOR_Report.php
+++ b/modules/AOR_Reports/AOR_Report.php
@@ -803,11 +803,12 @@ class AOR_Report extends Basic
             foreach ($fields as $name => $att) {
                 if ($att['display']) {
                     $html .= "<td class='' valign='top' align='left'>";
+                    if (!isset($row[$name])){
+                        $html .= "</td>";
+                        continue;
+                    }
                     if ($att['link'] && $links) {
                         $html .= "<a href='" . $sugar_config['site_url'] . "/index.php?module=" . $att['module'] . "&action=DetailView&record=" . $row[$att['alias'] . '_id'] . "'>";
-                    }
-                    if (!isset($row[$name])){
-                        continue;
                     }
 
                     $currency_id = isset($row[$att['alias'] . '_currency_id']) ? $row[$att['alias'] . '_currency_id'] : '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
Reports PDF export starts to break down when fields are empty.
If 1 field is empty on a row, the report table loses it's headers
if 2 fields are empty on a row in a row, the report pdf stops.

A table column tag is opened and never closed

## Motivation and Context
Reports PDF are not generating fully

## How To Test This
Test 1
- Create a report with multiple columns
- For the report data, make sure one fields is empty
- use the download PDF action
- see that the report table is malformed

Test 2
- For the report data, make sure 2 fields are empty in a row
- use the download PDF action
- see that the report stops at this point

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->