### PR TITLE
REL #7744 Remove Crypt_Blowfish: PHP4 Style Constructor

### DIFF
--- a/include/Pear/Crypt_Blowfish/Blowfish.php
+++ b/include/Pear/Crypt_Blowfish/Blowfish.php
@@ -102,21 +102,6 @@ class Crypt_Blowfish
     }
 
     /**
-     * @deprecated deprecated since version 7.6, PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code, use __construct instead
-     */
-    public function Crypt_Blowfish($key)
-    {
-        $deprecatedMessage = 'PHP4 Style Constructors are deprecated and will be remove in 7.8, please update your code';
-        if (isset($GLOBALS['log'])) {
-            $GLOBALS['log']->deprecated($deprecatedMessage);
-        } else {
-            trigger_error($deprecatedMessage, E_USER_DEPRECATED);
-        }
-        self::__construct($key);
-    }
-
-
-    /**
      * Deprecated isReady method
      *
      * @return bool


### PR DESCRIPTION
## Description

REL #7744

Deprecated code/functionality that needs to be removed in the next major version (7.12 or 8.0) of SuiteCRM.

Remove Crypt_Blowfish: PHP4 Style Constructor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->