### PR TITLE
CORE issue 10802 Attachments are not removed when replying to an email

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -4936,10 +4936,20 @@ eoq;
         Localization $locale,
         ?string $OBCharset
     ): void {
+        // Skip removed attachments
+        $removedAttachments = [];
+        if (!empty($_REQUEST['temp_remove_attachment'])) {
+            $removedAttachments = $_REQUEST['temp_remove_attachment'];
+        }
 ///////////////////////////////////////////////////////////////////////
         ////	ATTACHMENTS
         if (isset($this->saved_attachments)) {
             foreach ($this->saved_attachments as $note) {
+                // Skip removed attachments
+                if (in_array($note->id, $removedAttachments)) {
+                    continue;
+                }
+
                 $mime_type = 'text/plain';
                 if ($note->object_name == 'Note') {
                     if (!empty($note->file->temp_file_location) && is_file($note->file->temp_file_location)) { // brandy-new file upload/attachment


### PR DESCRIPTION
## Description

This fix resolves an issue where attachments were still being sent even after removing them while replying to an email.

When replying to an email that contains attachments, removing the attachments from the reply does not actually remove them before sending. The sent email still includes the removed attachments.

This fix updates the attachment handling logic in:

public/modules/Emails/Email.php

to ensure removed attachments are not included in the outgoing email.

Closes #10802


## Motivation and Context

Currently, when users reply to an email that contains attachments and manually remove those attachments before sending, the attachments are still included in the sent email.

This behavior is incorrect and causes unintended attachments to be sent to recipients.

The fix ensures that attachments removed from the email UI are properly excluded before sending.


## How To Test This

1. Open an email that contains attachments.
2. Click **Reply**.
3. Remove the attachments from the reply email.
4. Send the email.
5. Check the received email.

**Expected Result:**
Removed attachments should NOT be included in the sent email.

**Actual Result before fix:**
Removed attachments were still included in the sent email.

**Result after fix:**
Removed attachments are no longer included in the sent email.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Final checklist

- [x] My code follows the code style of this project found here:
https://docs.suitecrm.com/community/contributing-code/coding-standards/

- [ ] My change requires a change to the documentation.

- [x] I have read the How to Contribute guidelines:
https://docs.suitecrm.com/community/contributing-code/