### PR TITLE
Add SweetSpot dynamic global navigation

### DIFF
--- a/include/MVC/Controller/entry_point_registry.php
+++ b/include/MVC/Controller/entry_point_registry.php
@@ -99,4 +99,6 @@ $entry_point_registry = array(
     'setImapTestSettings' => ['file' => 'include/Imap/ImapTestSettingsEntry.php', 'auth' => true],
     'redirectToExternalOAuth' => ['file' => 'modules/ExternalOAuthConnection/entrypoint/redirectToExternalOAuth.php', 'auth' => true],
     'setExternalOAuthToken' => ['file' => 'modules/ExternalOAuthConnection/entrypoint/setExternalOAuthToken.php', 'auth' => true],
+    'suite_sweetspot_search' => array('file' => 'modules/Home/SweetspotSearch.php', 'auth' => true),
+    'suite_sweetspot_actions' => array('file' => 'modules/Home/SweetspotActions.php', 'auth' => true),
 );

--- a/include/MVC/View/SugarView.php
+++ b/include/MVC/View/SugarView.php
@@ -423,7 +423,7 @@ class SugarView
         ob_start();
         $this->renderJavascript();
 
-        $ss->assign("SUGAR_JS", ob_get_contents() . $themeObject->getJS());
+        $ss->assign("SUGAR_JS", ob_get_contents() . $themeObject->getJS() . $this->getSuiteSweetspotAssets());
         ob_end_clean();
 
         // get favicon
@@ -1041,6 +1041,36 @@ EOHTML;
             }
             echo "</script>\n";
         }
+    }
+
+    /**
+     * Inject Suite SweetSpot assets for authenticated users.
+     *
+     * @return string
+     */
+    protected function getSuiteSweetspotAssets()
+    {
+        global $sugar_config;
+
+        if (!isset($_SESSION['authenticated_user_id'])) {
+            return '';
+        }
+
+        if ($this->action === 'Login') {
+            return '';
+        }
+
+        if (isset($sugar_config['suite_sweetspot_enabled']) && !$sugar_config['suite_sweetspot_enabled']) {
+            return '';
+        }
+
+        $cssPath = getJSPath('include/css/suite_sweetspot.css');
+        $jsPath = getJSPath('include/javascript/suite_sweetspot.js');
+
+        return '<link rel="stylesheet" type="text/css" href="' . $cssPath . '"/>' .
+            "\n" .
+            '<script type="text/javascript" src="' . $jsPath . '"></script>' .
+            "\n";
     }
 
     /**

--- a/include/SuiteSweetspot/actions.php
+++ b/include/SuiteSweetspot/actions.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2026 SalesAgility Ltd.
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+/**
+ * Build action entries available to current user.
+ *
+ * @return array
+ */
+function suite_sweetspot_build_dynamic_actions()
+{
+    global $current_user, $app_list_strings, $mod_strings;
+
+    require_once 'include/utils.php';
+    require_once 'include/modules.php';
+    require_once 'modules/ACL/ACLController.php';
+
+    $actions = array();
+
+    $accessibleModules = query_module_access_list($current_user);
+    ACLController::filterModuleList($accessibleModules);
+
+    if (empty($app_list_strings['moduleList'])) {
+        require_once 'include/language/en_us.lang.php';
+    }
+
+    $moduleList = $app_list_strings['moduleList'] ?? array();
+
+    foreach ($accessibleModules as $moduleKey => $moduleValue) {
+        $moduleName = is_string($moduleValue) && !empty($moduleValue) ? $moduleValue : $moduleKey;
+
+        global $modInvisList;
+        if (isset($modInvisList) && in_array($moduleName, $modInvisList, true)) {
+            continue;
+        }
+
+        $label = $moduleList[$moduleName] ?? $moduleName;
+
+        suite_sweetspot_add_module_menu_actions($actions, $moduleName, $label);
+    }
+
+    global $beanList;
+    if (!empty($beanList)) {
+        foreach ($beanList as $moduleName => $beanClass) {
+            if (isset($actions[$moduleName . '_list'])) {
+                continue;
+            }
+
+            global $modInvisList;
+            if (isset($modInvisList) && in_array($moduleName, $modInvisList, true)) {
+                continue;
+            }
+
+            $label = $moduleList[$moduleName] ?? $moduleName;
+            suite_sweetspot_add_module_menu_actions($actions, $moduleName, $label);
+        }
+    }
+
+    suite_sweetspot_add_global_navigation_actions($actions);
+
+    if (is_admin($current_user)) {
+        suite_sweetspot_add_admin_actions($actions);
+    }
+
+    return $actions;
+}
+
+/**
+ * Add admin actions from admin panel definitions.
+ *
+ * @param array $actions
+ */
+function suite_sweetspot_add_admin_actions(&$actions)
+{
+    global $mod_strings, $admin_group_header;
+
+    require_once 'modules/Administration/language/en_us.lang.php';
+    if (empty($mod_strings)) {
+        $mod_strings = return_module_language('en_us', 'Administration');
+    }
+
+    $adminPanelFile = 'modules/Administration/metadata/adminpaneldefs.php';
+    if (!file_exists($adminPanelFile)) {
+        return;
+    }
+
+    $admin_option_defs = array();
+    $admin_group_header = array();
+
+    ob_start();
+    require $adminPanelFile;
+    ob_end_clean();
+
+    if (!empty($admin_group_header) && is_array($admin_group_header)) {
+        foreach ($admin_group_header as $group) {
+            if (empty($group[3]) || !is_array($group[3])) {
+                continue;
+            }
+
+            $allOptions = array();
+            foreach ($group[3] as $moduleKey => $moduleOptions) {
+                if (!is_array($moduleOptions)) {
+                    continue;
+                }
+
+                if (isset($moduleOptions[0]) && is_array($moduleOptions[0])) {
+                    foreach ($moduleOptions as $optionKey => $option) {
+                        if (is_array($option) && isset($option[3])) {
+                            $allOptions[] = array(
+                                'module' => $moduleKey,
+                                'key' => $optionKey,
+                                'option' => $option,
+                            );
+                        }
+                    }
+                } else {
+                    if (isset($moduleOptions[3])) {
+                        $allOptions[] = array(
+                            'module' => $moduleKey,
+                            'key' => $moduleKey,
+                            'option' => $moduleOptions,
+                        );
+                    } else {
+                        foreach ($moduleOptions as $optionKey => $option) {
+                            if (is_array($option) && isset($option[3])) {
+                                $allOptions[] = array(
+                                    'module' => $moduleKey,
+                                    'key' => $optionKey,
+                                    'option' => $option,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            foreach ($allOptions as $item) {
+                $option = $item['option'];
+                if (!is_array($option) || empty($option[3])) {
+                    continue;
+                }
+
+                $url = ltrim($option[3], './');
+                if (empty($url) || strpos($url, 'javascript:') === 0) {
+                    continue;
+                }
+
+                $labelKey = $option[1] ?? '';
+                $label = $labelKey;
+                if (!empty($mod_strings[$labelKey])) {
+                    $label = $mod_strings[$labelKey];
+                } elseif (!empty($option[0]) && is_string($option[0])) {
+                    $label = $option[0];
+                }
+
+                $id = 'admin_' . $item['module'] . '_' . $item['key'];
+                if (isset($actions[$id])) {
+                    continue;
+                }
+
+                $keywords = array(
+                    strtolower($label),
+                    strtolower($labelKey),
+                    strtolower($item['key']),
+                    'admin',
+                );
+
+                $actions[$id] = array(
+                    'id' => $id,
+                    'label' => $label,
+                    'module' => $item['module'],
+                    'url' => $url,
+                    'weight' => 30,
+                    'acl_action' => 'admin',
+                    'keywords' => $keywords,
+                );
+            }
+        }
+    }
+
+    $customAdminFile = 'custom/modules/Administration/Ext/Administration/administration.ext.php';
+    if (file_exists($customAdminFile)) {
+        $admin_option_defs = array();
+        ob_start();
+        include $customAdminFile;
+        ob_end_clean();
+
+        if (!empty($admin_option_defs) && is_array($admin_option_defs)) {
+            foreach ($admin_option_defs as $moduleKey => $moduleOptions) {
+                if (!is_array($moduleOptions)) {
+                    continue;
+                }
+
+                foreach ($moduleOptions as $optionKey => $option) {
+                    if (!is_array($option) || empty($option[3])) {
+                        continue;
+                    }
+
+                    $url = ltrim($option[3], './');
+                    if (empty($url) || strpos($url, 'javascript:') === 0) {
+                        continue;
+                    }
+
+                    $labelKey = $option[1] ?? '';
+                    $label = !empty($mod_strings[$labelKey]) ? $mod_strings[$labelKey] : ($option[0] ?? $labelKey);
+
+                    $id = 'admin_custom_' . $moduleKey . '_' . $optionKey;
+                    if (isset($actions[$id])) {
+                        continue;
+                    }
+
+                    $actions[$id] = array(
+                        'id' => $id,
+                        'label' => $label,
+                        'module' => $moduleKey,
+                        'url' => $url,
+                        'weight' => 30,
+                        'acl_action' => 'admin',
+                        'keywords' => array(strtolower($label), strtolower($labelKey), strtolower($optionKey), 'admin'),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Add module routes from module menu definitions, including custom menu extensions.
+ *
+ * @param array  $actions
+ * @param string $moduleName
+ * @param string $moduleLabel
+ */
+function suite_sweetspot_add_module_menu_actions(&$actions, $moduleName, $moduleLabel)
+{
+    $module_menu = array();
+    $menuFile = get_custom_file_if_exists('modules/' . $moduleName . '/Menu.php');
+    if (file_exists($menuFile)) {
+        require $menuFile;
+    }
+
+    $menuExtFile = 'custom/modules/' . $moduleName . '/Ext/Menus/menu.ext.php';
+    if (file_exists($menuExtFile)) {
+        require $menuExtFile;
+    }
+
+    if (empty($module_menu) || !is_array($module_menu)) {
+        return;
+    }
+
+    foreach ($module_menu as $idx => $menuItem) {
+        if (!is_array($menuItem) || empty($menuItem[0])) {
+            continue;
+        }
+
+        $url = (string)$menuItem[0];
+        if (strpos($url, 'javascript:') === 0) {
+            continue;
+        }
+
+        $label = isset($menuItem[1]) ? (string)$menuItem[1] : ('Open ' . $moduleLabel);
+        $icon = isset($menuItem[2]) ? (string)$menuItem[2] : '';
+        $id = 'menu_' . $moduleName . '_' . md5($url . '|' . $label . '|' . $idx);
+        if (isset($actions[$id])) {
+            continue;
+        }
+
+        $keywords = array(
+            strtolower($moduleName),
+            strtolower($moduleLabel),
+            strtolower($label),
+            'menu',
+        );
+
+        $actions[$id] = array(
+            'id' => $id,
+            'label' => $label,
+            'module' => $moduleName,
+            'url' => $url,
+            'icon' => $icon,
+            'weight' => 25,
+            'acl_action' => null,
+            'keywords' => $keywords,
+        );
+
+        if (!isset($actions[$moduleName . '_list']) && suite_sweetspot_is_list_url($url)) {
+            $actions[$moduleName . '_list'] = array(
+                'id' => $moduleName . '_list',
+                'label' => $moduleLabel,
+                'module' => $moduleName,
+                'url' => $url,
+                'icon' => $icon,
+                'weight' => 10,
+                'acl_action' => 'list',
+                'keywords' => array(strtolower($moduleLabel), strtolower($moduleName), 'list'),
+            );
+        }
+
+        if (!isset($actions[$moduleName . '_create']) && suite_sweetspot_is_create_url($url)) {
+            $actions[$moduleName . '_create'] = array(
+                'id' => $moduleName . '_create',
+                'label' => 'Create ' . $moduleLabel,
+                'module' => $moduleName,
+                'url' => $url,
+                'icon' => $icon,
+                'weight' => 20,
+                'acl_action' => 'edit',
+                'keywords' => array('create', strtolower($moduleLabel), 'new ' . strtolower($moduleLabel)),
+            );
+        }
+    }
+}
+
+/**
+ * Add dynamic global navigation links (home/profile/admin/user actions).
+ *
+ * @param array $actions
+ */
+function suite_sweetspot_add_global_navigation_actions(&$actions)
+{
+    $global_control_links = array();
+    require 'include/globalControlLinks.php';
+
+    foreach ($global_control_links as $section => $group) {
+        if (!is_array($group) || empty($group['linkinfo']) || !is_array($group['linkinfo'])) {
+            continue;
+        }
+
+        foreach ($group['linkinfo'] as $label => $url) {
+            if (empty($url) || strpos((string)$url, 'javascript:') === 0) {
+                continue;
+            }
+
+            $id = 'global_' . $section . '_' . md5($label . '|' . $url);
+            if (isset($actions[$id])) {
+                continue;
+            }
+
+            $labelString = (string)$label;
+            $actions[$id] = array(
+                'id' => $id,
+                'label' => $labelString,
+                'module' => ucfirst((string)$section),
+                'url' => (string)$url,
+                'weight' => 12,
+                'acl_action' => null,
+                'keywords' => array(strtolower($labelString), strtolower((string)$section), 'global'),
+            );
+        }
+    }
+}
+
+/**
+ * Determine whether a menu URL represents a list route.
+ *
+ * @param string $url
+ * @return bool
+ */
+function suite_sweetspot_is_list_url($url)
+{
+    $query = parse_url((string)$url, PHP_URL_QUERY);
+    if ($query === null) {
+        return false;
+    }
+
+    parse_str($query, $params);
+    if (empty($params['action'])) {
+        return true;
+    }
+
+    return strcasecmp((string)$params['action'], 'index') === 0 ||
+        strcasecmp((string)$params['action'], 'ListView') === 0;
+}
+
+/**
+ * Determine whether a menu URL represents a create route.
+ *
+ * @param string $url
+ * @return bool
+ */
+function suite_sweetspot_is_create_url($url)
+{
+    $query = parse_url((string)$url, PHP_URL_QUERY);
+    if ($query === null) {
+        return false;
+    }
+
+    parse_str($query, $params);
+    if (empty($params['action'])) {
+        return false;
+    }
+
+    return strcasecmp((string)$params['action'], 'EditView') === 0 ||
+        strcasecmp((string)$params['action'], 'QuickCreate') === 0;
+}
+
+/**
+ * Filter actions by ACL and user context.
+ *
+ * @param User $current_user
+ * @return array
+ */
+function suite_sweetspot_get_actions_for_user($current_user)
+{
+    $all = suite_sweetspot_build_dynamic_actions();
+
+    require_once 'include/utils.php';
+    require_once 'modules/ACL/ACLController.php';
+
+    $result = array();
+    foreach ($all as $id => $action) {
+        $module = !empty($action['module']) ? $action['module'] : null;
+        $aclAction = !empty($action['acl_action']) ? $action['acl_action'] : null;
+
+        if ($aclAction === 'admin') {
+            if (!is_admin($current_user)) {
+                continue;
+            }
+        } elseif ($module && $aclAction) {
+            if (!ACLController::checkAccess($module, $aclAction, true)) {
+                continue;
+            }
+        }
+
+        $result[$id] = $action;
+    }
+
+    uasort($result, function ($a, $b) {
+        $wa = isset($a['weight']) ? (int)$a['weight'] : 0;
+        $wb = isset($b['weight']) ? (int)$b['weight'] : 0;
+        if ($wa === $wb) {
+            $la = isset($a['label']) ? (string)$a['label'] : '';
+            $lb = isset($b['label']) ? (string)$b['label'] : '';
+            return strcasecmp($la, $lb);
+        }
+
+        return ($wa < $wb) ? -1 : 1;
+    });
+
+    return $result;
+}

--- a/include/css/suite_sweetspot.css
+++ b/include/css/suite_sweetspot.css
@@ -1,0 +1,122 @@
+.suite-sweetspot-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99998;
+    display: none;
+}
+
+#suite_sweetspot {
+    position: fixed;
+    top: 12%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 600px;
+    max-height: 600px;
+    z-index: 99999;
+    background: #2c3e50;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #eee;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    display: none;
+    overflow: hidden;
+}
+
+#suite_sweetspot .suite-sweetspot-searchbar {
+    padding: 16px 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#suite_sweetspot .suite-sweetspot-input {
+    flex: 1;
+    font-size: 16px;
+    padding: 10px 12px;
+    border: none;
+    outline: none;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.3);
+    color: #f5f5f5;
+}
+
+#suite_sweetspot .suite-sweetspot-results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    max-height: 450px;
+}
+
+#suite_sweetspot .suite-ss-section > p {
+    margin: 0;
+    padding: 10px 16px;
+    font-size: 11px;
+    text-transform: uppercase;
+    background: rgba(0, 0, 0, 0.3);
+    color: #95a5a6;
+    font-weight: 600;
+}
+
+#suite_sweetspot .suite-sweetspot-actions,
+#suite_sweetspot .suite-sweetspot-records {
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+}
+
+#suite_sweetspot li[data-sweetaction="true"] {
+    margin: 2px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+#suite_sweetspot li[data-sweetaction="true"] a {
+    color: #ecf0f1;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    padding: 10px 12px;
+}
+
+#suite_sweetspot .suite-ss-label {
+    font-size: 14px;
+    font-weight: 500;
+    flex: 1;
+}
+
+#suite_sweetspot .suite-ss-meta {
+    font-size: 12px;
+    color: #95a5a6;
+    margin-left: 10px;
+}
+
+#suite_sweetspot li[data-sweetaction="true"]:hover,
+#suite_sweetspot li[data-sweetaction="true"].active {
+    background: rgba(52, 152, 219, 0.25);
+}
+
+#suite_sweetspot .suite-sweetspot-footer {
+    padding: 10px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(0, 0, 0, 0.2);
+    display: flex;
+    justify-content: space-between;
+}
+
+#suite_sweetspot .suite-sweetspot-footer-hint {
+    font-size: 11px;
+    color: #7f8c8d;
+}
+
+#suite_sweetspot .suite-sweetspot-empty {
+    padding: 30px 20px;
+    text-align: center;
+    color: #7f8c8d;
+}

--- a/include/javascript/suite_sweetspot.js
+++ b/include/javascript/suite_sweetspot.js
@@ -1,0 +1,409 @@
+(function ($) {
+    'use strict';
+
+    if (typeof $ === 'undefined') {
+        return;
+    }
+
+    if (!window.SuiteSweetspot) {
+        window.SuiteSweetspot = {};
+    }
+
+    var SS = window.SuiteSweetspot;
+
+    SS.state = {
+        isVisible: false,
+        actions: [],
+        recordCache: {},
+        resultsFlat: [],
+        activeIndex: 0,
+        lastTerm: '',
+        searchTimer: null
+    };
+
+    SS.init = function () {
+        SS.createDom();
+        SS.bindGlobalShortcuts();
+        SS.bindOutsideClick();
+        SS.loadActions();
+    };
+
+    SS.createDom = function () {
+        if ($('#suite_sweetspot').length) {
+            return;
+        }
+
+        var html = ''
+            + '<div id="suite_sweetspot_backdrop" class="suite-sweetspot-backdrop" style="display:none;"></div>'
+            + '<div id="suite_sweetspot" class="suite-sweetspot" style="display:none;">'
+            + '  <div class="suite-sweetspot-searchbar">'
+            + '    <i class="fa fa-search suite-sweetspot-search-icon"></i>'
+            + '    <input type="text" class="suite-sweetspot-input" placeholder="Type to search modules, actions, or records..."/>'
+            + '    <span class="suite-sweetspot-hint">Ctrl+Shift+Space</span>'
+            + '  </div>'
+            + '  <ul class="suite-sweetspot-results">'
+            + '    <li data-section="actions" class="suite-ss-section"><p><i class="fa fa-bolt"></i> Actions</p><ul class="suite-sweetspot-actions"></ul></li>'
+            + '    <li data-section="records" class="suite-ss-section"><p><i class="fa fa-file-text"></i> Records</p><ul class="suite-sweetspot-records"></ul></li>'
+            + '  </ul>'
+            + '  <div class="suite-sweetspot-empty" style="display:none;"><i class="fa fa-search"></i><p>No results found</p><span>Try a different search term</span></div>'
+            + '  <div class="suite-sweetspot-footer">'
+            + '    <span class="suite-sweetspot-footer-hint"><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>'
+            + '    <span class="suite-sweetspot-footer-hint"><kbd>Enter</kbd> Select</span>'
+            + '    <span class="suite-sweetspot-footer-hint"><kbd>Esc</kbd> Close</span>'
+            + '  </div>'
+            + '</div>';
+
+        $('body').append(html);
+
+        $(document).on('keyup.suite_sweetspot_input', '#suite_sweetspot .suite-sweetspot-input', function (e) {
+            var code = e.which || e.keyCode;
+            if (code === 27 || code === 13 || code === 38 || code === 40) {
+                return;
+            }
+            SS.queueSearch($.trim($(this).val()));
+        });
+
+        $(document).on('click.suite_sweetspot_result', '#suite_sweetspot li[data-sweetaction="true"]', function (e) {
+            e.preventDefault();
+            var $a = $(this).find('a').first();
+            var url = $a.data('url');
+            if (!url) {
+                return;
+            }
+            SS.hide();
+            window.location = url;
+        });
+
+        $(document).on('click.suite_sweetspot_backdrop', '#suite_sweetspot_backdrop', function () {
+            SS.hide();
+        });
+    };
+
+    SS.bindGlobalShortcuts = function () {
+        $(document).on('keydown.suite_sweetspot_global', function (e) {
+            var code = e.which || e.keyCode;
+            if (e.ctrlKey && e.shiftKey && code === 32) {
+                e.preventDefault();
+                SS.toggle();
+            }
+        });
+    };
+
+    SS.bindOutsideClick = function () {
+        $(document).on('mousedown.suite_sweetspot_click', function (e) {
+            if (!SS.state.isVisible) {
+                return;
+            }
+            if (!$(e.target).closest('#suite_sweetspot').length) {
+                SS.hide();
+            }
+        });
+    };
+
+    SS.show = function () {
+        if (SS.state.isVisible) {
+            return;
+        }
+        SS.state.isVisible = true;
+        $('#suite_sweetspot_backdrop').fadeIn(100);
+        $('#suite_sweetspot').fadeIn(100).find('input.suite-sweetspot-input').val('').focus();
+        SS.state.lastTerm = '';
+        SS.state.resultsFlat = [];
+        SS.state.activeIndex = 0;
+        SS.bindInternalKeys();
+        SS.recalcMaxHeight();
+        SS.updateResultsForTerm('');
+    };
+
+    SS.hide = function () {
+        if (!SS.state.isVisible) {
+            return;
+        }
+        SS.state.isVisible = false;
+        $('#suite_sweetspot').fadeOut(100);
+        $('#suite_sweetspot_backdrop').fadeOut(100);
+        SS.unbindInternalKeys();
+        SS.state.activeIndex = 0;
+        SS.state.lastTerm = '';
+    };
+
+    SS.toggle = function () {
+        if (SS.state.isVisible) {
+            SS.hide();
+        } else {
+            SS.show();
+        }
+    };
+
+    SS.bindInternalKeys = function () {
+        $(document).on('keydown.suite_sweetspot_internal', function (e) {
+            if (!SS.state.isVisible) {
+                return;
+            }
+            var code = e.which || e.keyCode;
+            if (code === 27) {
+                e.preventDefault();
+                SS.hide();
+            } else if (code === 38) {
+                e.preventDefault();
+                SS.moveBackward();
+            } else if (code === 40) {
+                e.preventDefault();
+                SS.moveForward();
+            } else if (code === 13) {
+                e.preventDefault();
+                SS.executeActive();
+            }
+        });
+    };
+
+    SS.unbindInternalKeys = function () {
+        $(document).off('keydown.suite_sweetspot_internal');
+    };
+
+    SS.queueSearch = function (term) {
+        if (SS.state.searchTimer) {
+            window.clearTimeout(SS.state.searchTimer);
+        }
+        SS.state.searchTimer = window.setTimeout(function () {
+            SS.state.searchTimer = null;
+            SS.performSearch(term);
+        }, 200);
+    };
+
+    SS.performSearch = function (term) {
+        term = $.trim(term || '');
+        SS.state.lastTerm = term;
+        SS.updateResultsForTerm(term);
+
+        if (term === '') {
+            return;
+        }
+
+        $.ajax({
+            url: 'index.php',
+            type: 'GET',
+            dataType: 'json',
+            data: { entryPoint: 'suite_sweetspot_search', term: term, limit: 5 }
+        }).done(function (data) {
+            if (!data || !$.isArray(data.records)) {
+                return;
+            }
+            var now = new Date().getTime();
+            $.each(data.records, function (idx, rec) {
+                if (!rec || !rec.id) {
+                    return;
+                }
+                SS.state.recordCache[rec.id] = {
+                    id: rec.id,
+                    name: rec.name || '',
+                    module: rec.module || '',
+                    url: rec.url || '',
+                    _ts: now
+                };
+            });
+
+            if (SS.state.isVisible && SS.state.lastTerm === term) {
+                SS.updateResultsForTerm(term);
+            }
+        });
+    };
+
+    SS.updateResultsForTerm = function (term) {
+        term = $.trim(term || '');
+        var termLower = term.toLowerCase();
+        var actionsMatches = [];
+        var recordsMatches = [];
+
+        if (termLower !== '') {
+            $.each(SS.state.actions, function (idx, action) {
+                if (!action) {
+                    return;
+                }
+                var score = 0;
+                var label = (action.label || '').toLowerCase();
+                var module = (action.module || '').toLowerCase();
+                var keywords = action.keywords || [];
+                var hay = label + ' ' + module;
+
+                $.each(keywords, function (_, kw) {
+                    var kwLower = (kw || '').toLowerCase();
+                    if (kwLower === termLower) {
+                        score = 100;
+                        return false;
+                    } else if (kwLower.indexOf(termLower) === 0) {
+                        score = Math.max(score, 80);
+                    } else if (kwLower.indexOf(termLower) !== -1) {
+                        score = Math.max(score, 60);
+                    }
+                });
+
+                if (label.indexOf(termLower) === 0) {
+                    score = Math.max(score, 50);
+                } else if (label.indexOf(termLower) !== -1) {
+                    score = Math.max(score, 30);
+                }
+
+                if (module.indexOf(termLower) !== -1) {
+                    score = Math.max(score, 20);
+                }
+
+                if (hay.indexOf(termLower) !== -1 && score === 0) {
+                    score = 10;
+                }
+
+                if (score > 0) {
+                    actionsMatches.push({
+                        type: 'action',
+                        id: action.id,
+                        label: action.label || '',
+                        module: action.module || '',
+                        url: action.url || '',
+                        score: score
+                    });
+                }
+            });
+
+            actionsMatches.sort(function (a, b) {
+                if (a.score !== b.score) {
+                    return (b.score || 0) - (a.score || 0);
+                }
+                return (a.label || '').localeCompare(b.label || '');
+            });
+
+            $.each(SS.state.recordCache, function (id, rec) {
+                if (!rec) {
+                    return;
+                }
+                var hay = ((rec.name || '') + ' ' + (rec.module || '')).toLowerCase();
+                if (hay.indexOf(termLower) !== -1) {
+                    recordsMatches.push({
+                        type: 'record',
+                        id: rec.id,
+                        label: rec.name || '',
+                        module: rec.module || '',
+                        url: rec.url || ''
+                    });
+                }
+            });
+        }
+
+        SS.renderResults(actionsMatches, recordsMatches);
+    };
+
+    SS.renderResults = function (actionsMatches, recordsMatches) {
+        var $popup = $('#suite_sweetspot');
+        var $actionsUl = $popup.find('.suite-sweetspot-actions');
+        var $recordsUl = $popup.find('.suite-sweetspot-records');
+        $actionsUl.empty();
+        $recordsUl.empty();
+        SS.state.resultsFlat = [];
+        SS.state.activeIndex = 0;
+        var idx = 0;
+
+        $.each(actionsMatches, function (_, item) {
+            var $li = $('<li>').attr('data-sweetaction', 'true');
+            var $a = $('<a>').attr('href', item.url || 'javascript:void(0);').attr('data-url', item.url || '');
+            $a.append($('<span>').addClass('suite-ss-label').text(item.label));
+            $a.append($('<span>').addClass('suite-ss-meta').text(item.module));
+            $li.append($a);
+            $actionsUl.append($li);
+            SS.state.resultsFlat.push({ index: idx++, url: item.url, $el: $li });
+        });
+
+        $.each(recordsMatches, function (_, item) {
+            var $li = $('<li>').attr('data-sweetaction', 'true');
+            var $a = $('<a>').attr('href', item.url || 'javascript:void(0);').attr('data-url', item.url || '');
+            $a.append($('<span>').addClass('suite-ss-label').text(item.label));
+            $a.append($('<span>').addClass('suite-ss-meta').text(item.module));
+            $li.append($a);
+            $recordsUl.append($li);
+            SS.state.resultsFlat.push({ index: idx++, url: item.url, $el: $li });
+        });
+
+        var hasResults = actionsMatches.length > 0 || recordsMatches.length > 0;
+        $popup.find('li[data-section="actions"]').toggle(actionsMatches.length > 0);
+        $popup.find('li[data-section="records"]').toggle(recordsMatches.length > 0);
+        $popup.find('.suite-sweetspot-empty').toggle(!hasResults && SS.state.lastTerm !== '');
+
+        if (SS.state.resultsFlat.length > 0) {
+            SS.state.activeIndex = 0;
+            SS.updateActive();
+        } else {
+            SS.state.activeIndex = -1;
+        }
+    };
+
+    SS.moveForward = function () {
+        var max = SS.state.resultsFlat.length;
+        if (max === 0) {
+            return;
+        }
+        SS.state.activeIndex = (SS.state.activeIndex + 1) % max;
+        SS.updateActive();
+    };
+
+    SS.moveBackward = function () {
+        var max = SS.state.resultsFlat.length;
+        if (max === 0) {
+            return;
+        }
+        SS.state.activeIndex = (SS.state.activeIndex - 1 + max) % max;
+        SS.updateActive();
+    };
+
+    SS.updateActive = function () {
+        var list = SS.state.resultsFlat;
+        var idx = SS.state.activeIndex;
+        $('#suite_sweetspot li[data-sweetaction="true"]').removeClass('active');
+        if (!list || list.length === 0 || idx < 0 || idx >= list.length) {
+            return;
+        }
+        list[idx].$el.addClass('active');
+    };
+
+    SS.executeActive = function () {
+        var list = SS.state.resultsFlat;
+        var idx = SS.state.activeIndex;
+        if (!list || list.length === 0 || idx < 0 || idx >= list.length) {
+            return;
+        }
+        var entry = list[idx];
+        if (!entry || !entry.url) {
+            return;
+        }
+        SS.hide();
+        window.location = entry.url;
+    };
+
+    SS.recalcMaxHeight = function () {
+        var winH = $(window).height() || 600;
+        var maxH = Math.max(200, Math.min(520, winH - 100));
+        $('#suite_sweetspot').css('max-height', maxH + 'px');
+        $('#suite_sweetspot .suite-sweetspot-results').css('max-height', (maxH - 60) + 'px');
+    };
+
+    SS.loadActions = function () {
+        $.ajax({
+            url: 'index.php',
+            type: 'GET',
+            dataType: 'json',
+            data: { entryPoint: 'suite_sweetspot_actions' }
+        }).done(function (data) {
+            if (!data || !$.isArray(data.actions)) {
+                return;
+            }
+            SS.state.actions = data.actions;
+        });
+    };
+
+    $(window).on('resize.suite_sweetspot', function () {
+        if (SS.state.isVisible) {
+            SS.recalcMaxHeight();
+        }
+    });
+
+    $(function () {
+        SS.init();
+    });
+}(jQuery));

--- a/modules/Home/SweetspotActions.php
+++ b/modules/Home/SweetspotActions.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2026 SalesAgility Ltd.
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+require_once 'include/SuiteSweetspot/actions.php';
+
+global $current_user;
+global $sugar_config;
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if (isset($sugar_config['suite_sweetspot_enabled']) && !$sugar_config['suite_sweetspot_enabled']) {
+    echo json_encode(array('actions' => array()));
+    sugar_cleanup(true);
+}
+
+if (empty($current_user) || empty($current_user->id)) {
+    http_response_code(403);
+    echo json_encode(array(
+        'error' => 'not_authenticated',
+        'message' => 'User must be authenticated.',
+    ));
+    sugar_cleanup(true);
+}
+
+$actions = suite_sweetspot_get_actions_for_user($current_user);
+
+echo json_encode(array(
+    'actions' => array_values($actions),
+));
+
+sugar_cleanup(true);

--- a/modules/Home/SweetspotSearch.php
+++ b/modules/Home/SweetspotSearch.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2026 SalesAgility Ltd.
+ */
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+require_once 'include/SearchForm/SugarSpot.php';
+
+global $current_user;
+global $sugar_config;
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if (isset($sugar_config['suite_sweetspot_enabled']) && !$sugar_config['suite_sweetspot_enabled']) {
+    echo json_encode(array('records' => array()));
+    sugar_cleanup(true);
+}
+
+if (empty($current_user) || empty($current_user->id)) {
+    http_response_code(403);
+    echo json_encode(array(
+        'error' => 'not_authenticated',
+        'message' => 'User must be authenticated.',
+    ));
+    sugar_cleanup(true);
+}
+
+$term = isset($_REQUEST['term']) ? trim((string)$_REQUEST['term']) : '';
+if ($term === '' && isset($_REQUEST['query'])) {
+    $term = trim((string)$_REQUEST['query']);
+}
+if (strlen($term) > 255) {
+    $term = substr($term, 0, 255);
+}
+
+$maxRecords = 5;
+if (isset($_REQUEST['limit'])) {
+    $reqLimit = (int)$_REQUEST['limit'];
+    if ($reqLimit > 0 && $reqLimit <= 50) {
+        $maxRecords = $reqLimit;
+    }
+}
+
+if ($term === '') {
+    echo json_encode(array('records' => array()));
+    sugar_cleanup(true);
+}
+
+$spot = new SugarSpot('');
+$results = $spot->search($term);
+
+$records = array();
+$count = 0;
+foreach ($results as $moduleName => $moduleData) {
+    if (empty($moduleData['data']) || !is_array($moduleData['data'])) {
+        continue;
+    }
+
+    foreach ($moduleData['data'] as $row) {
+        if ($count >= $maxRecords) {
+            break 2;
+        }
+        if (empty($row['ID'])) {
+            continue;
+        }
+
+        $name = '';
+        if (!empty($row['NAME'])) {
+            $name = $row['NAME'];
+        } elseif (!empty($row['DOCUMENT_NAME'])) {
+            $name = $row['DOCUMENT_NAME'];
+        } else {
+            foreach ($row as $key => $value) {
+                if (strpos((string)$key, 'NAME') !== false && !empty($value)) {
+                    $name = $value;
+                    break;
+                }
+            }
+        }
+
+        $id = $row['ID'];
+        $recordUrl = suite_sweetspot_build_record_url($moduleName, $id);
+        $records[] = array(
+            'id' => $id,
+            'name' => $name,
+            'module' => $moduleName,
+            'url' => $recordUrl,
+        );
+        $count++;
+    }
+}
+
+echo json_encode(array('records' => $records));
+sugar_cleanup(true);
+
+/**
+ * Build a record URL using a bean when possible.
+ *
+ * @param string $moduleName
+ * @param string $id
+ * @return string
+ */
+function suite_sweetspot_build_record_url($moduleName, $id)
+{
+    if (!empty($GLOBALS['beanList'][$moduleName])) {
+        $bean = BeanFactory::newBean($moduleName);
+        if ($bean && method_exists($bean, 'getDetailViewURL')) {
+            $bean->id = $id;
+            $url = $bean->getDetailViewURL();
+            if (!empty($url)) {
+                return $url;
+            }
+        }
+    }
+
+    return 'index.php?' . http_build_query(array(
+        'module' => $moduleName,
+        'action' => 'DetailView',
+        'record' => $id,
+    ));
+}


### PR DESCRIPTION
I am grateful for the opportunity to contribute this feature to the SuiteCRM community.
If there are any changes needed to align with project standards, I would be happy to update the implementation.

## Summary
- add a keyboard-driven SweetSpot command palette UI and backend endpoints for global navigation/search
- dynamically discover module and admin routes from menu/admin definitions, including custom extensions
- integrate feature into SuiteCRM core flow via entry point registry and authenticated asset injection with config toggle support

## Test plan
- [ ] Open SuiteCRM as authenticated user and verify `Ctrl+Shift+Space` opens the SweetSpot overlay
- [ ] Confirm module list/create and admin actions appear based on ACL permissions
- [ ] Verify unified search results open valid record URLs
- [ ] Set `suite_sweetspot_enabled` to `false` and confirm assets/endpoints are effectively disabled