### PR TITLE
Fix #10819 issue with email import autocomplete

### DIFF
--- a/include/SugarFields/Fields/Parent/SearchView.tpl
+++ b/include/SugarFields/Fields/Parent/SearchView.tpl
@@ -66,29 +66,32 @@ onchange='document.{{$form_name}}.{{sugarvar key='name'}}.value="";document.{{$f
 if (typeof(changeParentQSSearchView) == 'undefined'){
 function changeParentQSSearchView(field) {
 	field = YAHOO.util.Dom.get(field);
-    var sqs_objects = {};
     var form = field.form;
     var sqsId = form.id + "_" + field.id;
     var typeField =  form.elements["{{$vardef.type_name}}"];
     var new_module = typeField.value;
-    if(typeof(disabledModules[new_module]) != 'undefined') {
-		sqs_objects[sqsId]["disable"] = true;
-		field.readOnly = true;
-	} else {
-		sqs_objects[sqsId]["disable"] = false;
-		field.readOnly = false;
-    }
-	//Update the SQS globals to reflect the new module choice
-    sqs_objects[sqsId]["modules"] = new Array(new_module);
-    if (typeof(QSFieldsArray[sqsId]) != 'undefined')
+
+    if(typeof(sqs_objects[sqsId]) !== 'undefined')
     {
-        QSFieldsArray[sqsId].sqs.modules = new Array(new_module);
+	  if(typeof(disabledModules[new_module]) != 'undefined') {
+            sqs_objects[sqsId]["disable"] = true;
+            field.readOnly = true;
+        } else {
+            sqs_objects[sqsId]["disable"] = false;
+            field.readOnly = false;
+        }
+        //Update the SQS globals to reflect the new module choice
+        sqs_objects[sqsId]["modules"] = new Array(new_module);
+        if (typeof(QSFieldsArray[sqsId]) != 'undefined')
+        {
+            QSFieldsArray[sqsId].sqs.modules = new Array(new_module);
+        }
+        if(typeof(QSProcessedFieldsArray) != 'undefined')
+        {
+           QSProcessedFieldsArray[sqsId] = false;
+        }
+        enableQS(false);
     }
-	if(typeof QSProcessedFieldsArray != 'undefined')
-    {
-	   QSProcessedFieldsArray[sqsId] = false;
-    }
-    enableQS(false);
 }}
 YAHOO.util.Event.onContentReady(
 {/literal}

--- a/modules/Emails/include/ImportView/ImportView.tpl
+++ b/modules/Emails/include/ImportView/ImportView.tpl
@@ -183,3 +183,42 @@
     {/literal}
     {/if}
 </form>
+{literal}
+<script type="text/javascript">
+function parentQS(field) {
+window.sqs_objects['EditView_parent_name'] = {{$qsName}};
+registerSingleSmartInputListener(document.getElementById('parent_name'));
+{/literal}
+addToValidateBinaryDependency('EditView', 'parent_name', 'alpha', false, '{$app_strings['ERR_SQS_NO_MATCH_FIELD']} {$app_strings['LBL_ASSIGNED_TO']}','parent_id');
+{literal}
+field = YAHOO.util.Dom.get(field);
+            var form = field.form;
+            var sqsId = form.id + "_" + field.id;
+            var typeField =  form.elements["parent_type"];
+            var new_module = typeField.value;
+            if(typeof(disabledModules[new_module]) != 'undefined') {
+                window.sqs_objects[sqsId]["disable"] = true;
+                field.readOnly = true;
+            } else {
+                window.sqs_objects[sqsId]["disable"] = false;
+                field.readOnly = false;
+            }
+            //Update the SQS globals to reflect the new module choice
+            window.sqs_objects[sqsId]["modules"] = new Array(new_module);
+            if (typeof(window.QSFieldsArray[sqsId]) != 'undefined')
+            {
+                window.QSFieldsArray[sqsId].sqs.modules = new Array(new_module);
+            }
+            if(typeof window.QSProcessedFieldsArray != 'undefined')
+            {
+                window.QSProcessedFieldsArray[sqsId] = false;
+            }
+            window.enableQS(false);
+}
+YAHOO.util.Event.onContentReady('parent_name', function() {
+    parentQS('parent_name');
+});
+var disabledModules='{$disabled_parent_types}';
+</script>
+
+{/literal}

--- a/modules/Emails/views/view.import.php
+++ b/modules/Emails/views/view.import.php
@@ -72,11 +72,29 @@ class EmailsViewImport extends ViewEdit
      */
     public function preDisplay()
     {
-        global $current_user;
+        global $current_user, $app_strings;
 
         $metadataFile = $this->getMetaDataFile();
         $this->ev = $this->getEditView();
         $this->ev->ss =& $this->ss;
+
+
+        // QuickSearch
+        $qsName = array(
+            'form' => 'EditView',
+            'method' => 'query',
+            'modules' => array(),
+            'group' => 'or',
+            'field_list' => array('name', 'id'),
+            'populate_list' => array("parent_name", "parent_id"),
+            'conditions' => array(array('name' => 'name', 'op' => 'like_custom', 'end' => '%', 'value' => '')),
+            'limit' => '30',
+            'no_match_text' => $app_strings['ERR_SQS_NO_MATCH']
+        );
+        $json = getJSONobj();
+        $qsName = $json->encode($qsName);
+        $this->ev->ss->assign('qsName', $qsName);
+
 
         // Set a distinct view name to avoid cache conflicts with regular edit view
         $this->ev->formName = 'EditNonImported';


### PR DESCRIPTION
Update javascript to enable autocomplete

## Description
When importing emails from the list view on the import modal relate field when a module is selected the autocomplete does not work.

## Motivation and Context
Enables autocomplete when importing emails with related modules.

## How To Test This
See issue #10819

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->