### PR TITLE
Improve sugar_mkdir error handling

### DIFF
--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -72,8 +72,26 @@ function sugar_mkdir($pathname, $mode = null, $recursive = false, $context = nul
     if (empty($mode)) {
         $mode = 0777;
     }
+
+    $result = false;
     if (empty($context)) {
-        $result = @mkdir($pathname, $mode, $recursive);
+        try {
+            $result = mkdir($pathname, $mode, $recursive);
+        } catch(Throwable $e) {
+            // for hardened PHP-FPM installs without CAP_FSETID, retry the mkdir
+            // but drop the special bits from the mode (e.g. 02775 is retried as 0775)
+            if (strpos($e->getMessage(), 'not permitted') !== false) {
+                $result = @mkdir($pathname, $mode & 0777, $recursive);
+            }
+        }
+        // mkdir() also emits E_WARNING on failure (not always catchable as exception),
+        // so check error_get_last() as a fallback for the same condition
+        if (!$result) {
+            $error = error_get_last();
+            if ($error !== null && strpos($error['message'], 'not permitted') !== false) {
+                $result = @mkdir($pathname, $mode & 0777, $recursive);
+            }
+        }
     } else {
         $result = @mkdir($pathname, $mode, $recursive, $context);
     }
@@ -94,8 +112,8 @@ function sugar_mkdir($pathname, $mode = null, $recursive = false, $context = nul
         }
     } else {
         $errorMessage = "Cannot create directory $pathname cannot be touched";
-        if (is_null($GLOBALS['log'])) {
-            throw new Exception("Error occurred but the system doesn't have logger. Error message: \"$errorMessage\"");
+        if (is_null($GLOBALS['log']) || !$GLOBALS['log']->wouldLog('error')) {
+            throw new Exception("Error occurred in sugar_mkdir but the system doesn't have logger. Error message: \"$errorMessage\"");
         }
         $GLOBALS['log']->error($errorMessage);
     }

--- a/include/utils/sugar_file_utils.php
+++ b/include/utils/sugar_file_utils.php
@@ -73,27 +73,27 @@ function sugar_mkdir($pathname, $mode = null, $recursive = false, $context = nul
         $mode = 0777;
     }
 
-    $result = false;
     if (empty($context)) {
-        try {
-            $result = mkdir($pathname, $mode, $recursive);
-        } catch(Throwable $e) {
-            // for hardened PHP-FPM installs without CAP_FSETID, retry the mkdir
-            // but drop the special bits from the mode (e.g. 02775 is retried as 0775)
-            if (strpos($e->getMessage(), 'not permitted') !== false) {
-                $result = @mkdir($pathname, $mode & 0777, $recursive);
-            }
+        $context = null;
+    }
+
+    $result = false;
+    try {
+        $result = mkdir($pathname, $mode, $recursive, $context);
+    } catch(Throwable $e) {
+        // for hardened PHP-FPM installs without CAP_FSETID, retry the mkdir
+        // but drop the special bits from the mode (e.g. 02775 is retried as 0775)
+        if (strpos($e->getMessage(), 'not permitted') !== false) {
+            $result = @mkdir($pathname, $mode & 0777, $recursive, $context);
         }
-        // mkdir() also emits E_WARNING on failure (not always catchable as exception),
-        // so check error_get_last() as a fallback for the same condition
-        if (!$result) {
-            $error = error_get_last();
-            if ($error !== null && strpos($error['message'], 'not permitted') !== false) {
-                $result = @mkdir($pathname, $mode & 0777, $recursive);
-            }
+    }
+    // mkdir() also emits E_WARNING on failure (not always catchable as exception),
+    // so check error_get_last() as a fallback for the same condition
+    if (!$result) {
+        $error = error_get_last();
+        if ($error !== null && strpos($error['message'], 'not permitted') !== false) {
+            $result = @mkdir($pathname, $mode & 0777, $recursive, $context);
         }
-    } else {
-        $result = @mkdir($pathname, $mode, $recursive, $context);
     }
 
     if ($result) {
@@ -112,10 +112,10 @@ function sugar_mkdir($pathname, $mode = null, $recursive = false, $context = nul
         }
     } else {
         $errorMessage = "Cannot create directory $pathname cannot be touched";
-        if (is_null($GLOBALS['log']) || !$GLOBALS['log']->wouldLog('error')) {
+        if (is_null($GLOBALS['log'])) {
             throw new Exception("Error occurred in sugar_mkdir but the system doesn't have logger. Error message: \"$errorMessage\"");
         }
-        $GLOBALS['log']->error($errorMessage);
+        $GLOBALS['log']->fatal($errorMessage);
     }
 
     return $result;
@@ -315,7 +315,7 @@ function sugar_touch($filename, $time = null, $atime = null)
     // We need to check if is a local file, it can be a stream wrapper (ex: upload://myfile.txt)
     // touch is only available in local files
     $result = false;
-    if (is_string($filename) && !empty($filename) && 
+    if (is_string($filename) && !empty($filename) &&
         stream_is_local($filename)) {
         if (!empty($atime) && !empty($time)) {
             $result = @touch($filename, $time, $atime);


### PR DESCRIPTION

## Enhanced error handling for directory creation

**TLDR; sugar_mkdir failures should be considered critical, and a proper message should _always_ be logged. Failures should be circumvented when possible.**


A good number of people showing up in the forums with broken initial installations is stumbling with the typical ownership-permissions errors. Although this problem is "classical", there are some new factors at play due to the change to Suite8 and to the modernization of PHP.

- Added fallback for permission errors which are appearing in modern Ubuntu's etc due to PHP-FPM hardening
- Improved logging in some early moments of installation when the normal log is not available yet or the log level is not sufficient. This really helps to prevent critical, yet silent failures that leave people clueless
- this new code is much better at showing permissions errors for what they are, instead of letting them creep up later as 
  - missing CSS
  - missing screen elements
  - during initial login as "Login credentials incorrect"


## Motivation and Context

I spent two days installing SuiteCRM on Ubuntu 26. I am a pro at installing SuiteCRM. If it takes me 2 days, most other people will likely just give up.

Granted, it took me 2 days because I wasn't just trying to get it to work, I was stubbornly trying to understand _why_ it wasn't working, connecting a debugger, making sure each problem I discovered was getting properly logged etc.

## How To Test This

This helper sugar_mkdir function is used all over the place, so it affects basically everything. But the two main test cases I would recommend looking at:

1. initial installation, in Ubuntu 26, with PHP-FPM, using a permissions scheme which includes a SetGID bit: `2775` or similar. 
2. in normal usage after already installed, delete the entire cache dir and see if recovers well: `sudo rm -rf /var/www/suitecrm/public/legacy/cache/`

You can also redo those two test cases but with broken permissions.

1. try an initial install with broken ownerships or permissions, check that you can see a relevant log message indicating this (might show up in `php_errors.log` or in `suitecrm.log` (v7) or in `logs/prod/prod.log` (v8)
2. in normal usage after already installed, delete the entire cache dir and recreate it manually with some incorrect ownerships, for example, so that it is not writable. Check that you can see a relevant log message indicating this.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
