### PR TITLE
Fix #10889 - Workflow - Calculated fields: Text value will be handled as decimal

### DIFF
--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -107,10 +107,13 @@ class actionComputeField extends actionBase
              for ($i = 0; $i < $formulasCount; $i++) {
                 if (array_key_exists($formulas[$i], $relateFields) && isset($relateFields[$formulas[$i]]['id_name'])) {
                     $calcValue = $calculator->calculateFormula($formulaContents[$i]);
-                    $bean->{$relateFields[$formulas[$i]]['id_name']} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+                    $id_name = $relateFields[$formulas[$i]]['id_name'];
+                    $type = $bean->field_defs[$id_name]['type'] ?? '';
+                    $bean->{$id_name} = ( in_array($type, ['int', 'float', 'decimal', 'currency']) && is_numeric($calcValue) ? (float)$calcValue : $calcValue );
                 } else {
                     $calcValue = $calculator->calculateFormula($formulaContents[$i]);
-                    $bean->{$formulas[$i]} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+                    $type = $bean->field_defs[$formulas[$i]]['type'] ?? '';
+                    $bean->{$formulas[$i]} = ( in_array($type, ['int', 'float', 'decimal', 'currency']) && is_numeric($calcValue) ? (float)$calcValue : $calcValue );
                 }
             }
 


### PR DESCRIPTION
Fixes #10889

The workflow `actionComputeField` was checking `is_numeric($calcValue)` before assigning a calculated value to a bean field. If this evaluated to true, it automatically cast the value to a `(float)`.

While this correctly handles numeric data, it had the unintended side effect of casting text strings consisting entirely of numbers (e.g., `"0123"`) into floats, effectively stripping the leading zeros before saving the value into the destination field.

This PR modifies `modules/AOW_Actions/actions/actionComputeField.php` to first check the destination field's vardef `type`. The `(float)` cast is now strictly applied only if the destination field is genuinely a numeric type (`int`, `float`, `decimal`, `currency`). For all other field types (such as `varchar`, `phone`, `text`), the exact string is preserved.

## Motivation and Context

This change is required because users were unable to use workflow calculated fields to copy string values like ZIP codes, case numbers, or phone numbers that begin with a zero, without the data mutating and losing the leading zero.

## How To Test This

1. Go to __Admin > Studio__ and add two new fields of type `TextField` (e.g., `Field A` and `Field B`) to the __Cases__ module.

2. Go to __Workflows__ and create a workflow for the __Cases__ module.

3. Add a __Calculate Fields__ action:

   - Add parameter `P0` using `Field A` (Raw Value).
   - Add a formula targeting `Field B`, and type `{P0}` in the formula box.

4. Create a new Case record.

5. In `Field A`, type a number with a leading zero (e.g., `"0123"`).

6. Click __Save__.

7. Observe `Field B`. Without this PR, it displays `"123"`. With this PR, it correctly displays the text `"0123"`.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)
