### PR TITLE
fix: suiteP theme in 7.8.2 is ignoring maxColumns

### DIFF
--- a/themes/SuiteP/include/DetailView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/DetailView/tab_panel_content.tpl
@@ -40,6 +40,14 @@
  *}
 {*<!-- tab_panel_content.tpl START -->*}
 
+{{if isset($maxColumns) && $maxColumns > 0}}
+    {{assign var="panelMaxColumns" value=$maxColumns}}
+{{else}}
+    {{assign var="panelMaxColumns" value=2}}
+{{/if}}
+{{math assign="panelColumnWidth" equation="max(1, floor(12 / $panelMaxColumns))"}}
+{{math assign="panelFullWidthColspan" equation="2 * $panelMaxColumns - 1"}}
+
 {*<!-- tab panel main div -->*}
 
 {{foreach name=rowIteration from=$panel key=row item=rowData}}
@@ -57,9 +65,9 @@
 
         {*<!-- COLUMN -->*}
 
-        {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
+        {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != $panelFullWidthColspan}}
             {*<!-- DIV column - colspan != 3 -->*}
-            <div class="col-xs-12 col-sm-6 detail-view-row-item" data-field="{{$colData.field.name}}">
+            <div class="col-xs-12 col-sm-{{$panelColumnWidth}} detail-view-row-item" data-field="{{$colData.field.name}}">
         {{else}}
             {*<!-- DIV column - colspan = 3 -->*}
             <div class="col-xs-12 col-sm-12 detail-view-row-item" data-field="{{$colData.field.name}}">
@@ -75,7 +83,7 @@
 
                 {{if $fieldCount < $smarty.foreach.colIteration.total && !empty($colData.field.name)}}
 
-                    {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
+                    {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != $panelFullWidthColspan}}
                         {*<!-- DIV inside - colspan != 3 -->*}
 
                     {{if $smarty.foreach.colIteration.index == 0}}
@@ -119,7 +127,7 @@
                     </div>
                     {*<!-- /DIV inside  -->*}
 
-                    {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
+                    {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != $panelFullWidthColspan}}
                         {*<!-- phone (version 1) -->*}
                         <div class="col-xs-12 col-sm-8 detail-view-field{{if $inline_edit && !empty($colData.field.name) && ($fields[$colData.field.name].inline_edit == 1 || !isset($fields[$colData.field.name].inline_edit))}} inlineEdit{{/if}}{{if isset($fields[$colData.field.name].type) && $fields[$colData.field.name].type == 'phone'}} phone{{/if}}" type="{{$fields[$colData.field.name].type}}" field="{{$fields[$colData.field.name].name}}" {{if $colData.colspan}}colspan='{{$colData.colspan}}'{{/if}}>
                     {{else}}

--- a/themes/SuiteP/include/EditView/tab_panel_content.tpl
+++ b/themes/SuiteP/include/EditView/tab_panel_content.tpl
@@ -1,4 +1,11 @@
     <!-- tab_panel_content.tpl -->
+    {{if isset($maxColumns) && $maxColumns > 0}}
+        {{assign var="panelMaxColumns" value=$maxColumns}}
+    {{else}}
+        {{assign var="panelMaxColumns" value=2}}
+    {{/if}}
+    {{math assign="panelColumnWidth" equation="max(1, floor(12 / $panelMaxColumns))"}}
+    {{math assign="panelFullWidthColspan" equation="2 * $panelMaxColumns - 1"}}
     <div class="row edit-view-row">
         {{foreach name=rowIteration from=$panel key=row item=rowData}}
             {*row*}
@@ -6,8 +13,8 @@
             {{foreach name=colIteration from=$rowData key=col item=colData}}
                 {*column*}
                 {*<!-- COLUMN -->*}
-                {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
-                    <div class="col-xs-12 col-sm-6 edit-view-row-item" data-field="{{$colData.field.name}}">
+                {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != $panelFullWidthColspan}}
+                    <div class="col-xs-12 col-sm-{{$panelColumnWidth}} edit-view-row-item" data-field="{{$colData.field.name}}">
                 {{else}}
                     <div class="col-xs-12 col-sm-12 edit-view-row-item" data-field="{{$colData.field.name}}">
                 {{/if}}
@@ -25,7 +32,7 @@
                         {{else}}
 
                         {*<!-- LABEL -->*}
-                        {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != 3}}
+                        {{if $smarty.foreach.colIteration.total > 1 && $colData.colspan != $panelFullWidthColspan}}
                             <div class="col-xs-12 col-sm-4 label" data-label="{{$fields[$colData.field.name].vname|default:''}}">
                         {{else}}
                              <div class="col-xs-12 col-sm-2 label" data-label="{{$fields[$colData.field.name].vname|default:''}}">
@@ -65,7 +72,7 @@
                         {{/if}}
 
                         {*<!-- VALUE -->*}
-                        {{if !empty($colData.field.hideLabel) && $colData.field.hideLabel == true && $colData.colspan != 3}}
+                        {{if !empty($colData.field.hideLabel) && $colData.field.hideLabel == true && $colData.colspan != $panelFullWidthColspan}}
                             {{assign var="fieldClasses" value="col-xs-12 col-sm-12"}}
                         {{else}}
                             {{assign var="fieldClasses" value="col-xs-12 col-sm-8"}}
@@ -137,7 +144,7 @@
                     {{counter name="fieldCount" print=false}}
                 {{/foreach}}
                 </div>
-                {{if intval($col)%2==1}}
+                {{if intval($col) % $panelMaxColumns == $panelMaxColumns - 1}}
                 <div class="clear"></div>
                 {{/if}}
             {{/foreach}}


### PR DESCRIPTION
Fixes #3310

## Root cause

SuiteP panel templates hardcode a 2-column Bootstrap grid

## Changes

- Derive the Bootstrap column width and the full-row colspan threshold from the maxColumns value already assigned to Smarty by EditView2::process, instead of hardcoding col-sm-6 and colspan == 3. Also derive the EditView intra-row clearfix from maxColumns instead of every 2nd column. Falls back to 2 columns when maxColumns is absent, so default layouts render byte-identically.