### PR TITLE
Fix #10904 - Retrieve saved search contents without HTML encoding

### DIFF
--- a/modules/SavedSearch/SavedSearch.php
+++ b/modules/SavedSearch/SavedSearch.php
@@ -492,7 +492,7 @@ class SavedSearch extends SugarBean
 
     public function retrieveSavedSearch($id)
     {
-        parent::retrieve($id);
+        parent::retrieve($id, false);
         $this->contents = unserialize(base64_decode($this->contents), ['allowed_classes' => false]);
     }
 


### PR DESCRIPTION
## Description

Passes `false` as the `$encode` argument when `SavedSearch::retrieveSavedSearch()` loads the structured `contents` field.

This is the Legacy-repository counterpart of [SuiteCRM-Core#1012](https://github.com/SuiteCRM/SuiteCRM-Core/pull/1012), recreated here at the maintainers' request. The original Core PR remains open for its SuiteCRM 8 regression test and review history.

## Motivation and Context

Fixes #10904.

SuiteCRM 8.9.3 migrated saved-search contents to JSON. With the default `SugarBean::retrieve()` behavior, JSON quotes are HTML-encoded before the SavedSearch decoder receives the value. Decoding then fails and selecting an entry from **My Filters** redirects to the dashboard.

The `SuiteCRM/SuiteCRM` `hotfix` branch currently still stores this field as Base64-encoded PHP serialization, so this one-line change preserves its current behavior. It also gives the structured field the correct raw-read semantics when Legacy changes are synchronized into SuiteCRM 8. The JSON-specific regression test remains in SuiteCRM-Core#1012 because the JSON decoder and migration are not present in this branch.

## How To Test This

1. Run `php -l modules/SavedSearch/SavedSearch.php`.
2. On standalone SuiteCRM 7.15.2, save and retrieve a filter and confirm the existing Base64 round trip is unchanged.
3. In SuiteCRM 8.10.2, apply the equivalent change under `public/legacy`, save a filter, and select it from **My Filters**.
4. Confirm the filter opens its module with its saved criteria, ordering, and columns instead of redirecting to the dashboard.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
