### PR TITLE
Add SuiteCRM Store link to user dropdown

### DIFF
--- a/include/globalControlLinks.php
+++ b/include/globalControlLinks.php
@@ -78,6 +78,10 @@ $global_control_links['training'] = array(
 'submenu' => ''
  );
 
+$global_control_links['suitecrm_store'] = array(
+'linkinfo' => array($app_strings['LBL_SUITECRM_STORE'] => 'https://store.suitecrm.com', 'target' => '_blank'),
+'submenu' => ''
+);
 /* no longer goes in the menubar - now implemented in the bottom bar.
 $global_control_links['help'] = array(
     'linkinfo' => array($app_strings['LNK_HELP'] => ' javascript:void window.open(\'index.php?module=Administration&action=SupportPortal&view=documentation&version='.$sugar_version.'&edition='.$sugar_flavor.'&lang='.$current_language.'&help_module='.$GLOBALS['module'].'&help_action='.$action.'&key='.$server_unique_key.'\')'),

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -1927,6 +1927,7 @@ $app_strings = array(
     'LBL_NEXT_BTN' => 'Next',
     'LBL_ONLY_IMAGE_ATTACHMENT' => 'Only the following supported image type attachments can be embedded: JPG, PNG.',
     'LBL_TRAINING' => 'Support Forum',
+    'LBL_SUITECRM_STORE' => 'SuiteCRM Store',
     'ERR_MSSQL_DB_CONTEXT' => 'Changed database context to',
     'ERR_MSSQL_WARNING' => 'Warning:',
 


### PR DESCRIPTION
## Description

Adds a link to the SuiteCRM Store in the user profile dropdown menu.

The link uses the existing global control links mechanism and opens the SuiteCRM Store in a new browser tab.

## Changes

- Added SuiteCRM Store to the global control links.
- Added a translatable `LBL_SUITECRM_STORE` application string.
- Opens `https://store.suitecrm.com` in a new tab.

## Testing

- Verified the SuiteCRM Store link appears in the user dropdown.
- Verified the link opens the SuiteCRM Store in a new tab.
- Verified PHP syntax for the modified files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->