### PR TITLE
Fix Maps drawing tools by replacing Google DrawingManager with Terra Draw

### DIFF
--- a/modules/jjwg_Maps/controller.php
+++ b/modules/jjwg_Maps/controller.php
@@ -686,7 +686,7 @@ class jjwg_MapsController extends SugarController
                     $map_parent_type = $_REQUEST['relate_module'];
                     $map_parent_id = $_REQUEST['relate_id'];
                     $map_module_type = (!empty($_REQUEST['display_module'])) ? $_REQUEST['display_module'] : $_REQUEST['relate_module'];
-                    $map_distance = (!empty($_REQUEST['distance'])) ? (float)$_REQUEST['distance'] : $this->settings['map_default_distance'];
+                    $map_distance = (!empty($_REQUEST['distance'])) ? $_REQUEST['distance'] : $this->settings['map_default_distance'];
                     $map_unit_type = (!empty($_REQUEST['unit_type'])) ? $_REQUEST['unit_type'] : $this->settings['map_default_unit_type'];
                 }
                 // Else if a 'quick_address' use it as the Center Point (Lng/Lat)
@@ -696,7 +696,7 @@ class jjwg_MapsController extends SugarController
                         $map_parent_type = null;
                         $map_parent_id = null;
                         $map_module_type = (!empty($_REQUEST['display_module'])) ? $_REQUEST['display_module'] : $_REQUEST['relate_module'];
-                        $map_distance = (!empty($_REQUEST['distance'])) ? (float)$_REQUEST['distance'] : $this->settings['map_default_distance'];
+                        $map_distance = (!empty($_REQUEST['distance'])) ? $_REQUEST['distance'] : $this->settings['map_default_distance'];
                         $map_unit_type = (!empty($_REQUEST['unit_type'])) ? $_REQUEST['unit_type'] : $this->settings['map_default_unit_type'];
                     }
                 }
@@ -946,6 +946,18 @@ class jjwg_MapsController extends SugarController
                     "" . $this->display_object->table_name . "_cstm.jjwg_maps_lng_c != 0) " .
                     " AND " .
                     "(" . $this->display_object->table_name . "_cstm.jjwg_maps_geocode_status_c = 'OK')";
+            // FIX: Scope the query itself to the requested records (uid list, or the ids resolved
+            // from an advanced search) BEFORE the LIMIT below is applied. Previously $records was
+            // only checked in PHP after fetching, so on installs with more geocoded records than
+            // 'map_markers_limit' the requested records were frequently outside that arbitrary,
+            // unordered first page and were silently dropped.
+            if (!empty($records)) {
+                $quoted_ids = array();
+                foreach ($records as $record_id) {
+                    $quoted_ids[] = "'" . $this->bean->db->quote($record_id) . "'";
+                }
+                $where_conds .= " AND " . $this->display_object->table_name . ".id IN (" . implode(',', $quoted_ids) . ")";
+            }
             $query = $this->display_object->create_new_list_query('', $where_conds, array(), array(), 0, '', false, $this->display_object, false);
             if ($display_module == 'Contacts') { // Contacts - Account Name
                 $query = str_replace(' FROM contacts ', ' ,accounts.name AS account_name, accounts.id AS account_id  FROM contacts  ', (string) $query);
@@ -959,16 +971,30 @@ class jjwg_MapsController extends SugarController
             $display_result = $this->bean->db->limitQuery($query, 0, $this->settings['map_markers_limit']);
             $this->bean->map_markers = array();
             while ($display = $this->bean->db->fetchByAssoc($display_result)) {
+                // FIX: getMarkerData() returns false when a record's lat/lng fails range validation
+                // (is_valid_lat/is_valid_lng), which can happen even after the SQL geocode filter
+                // above, e.g. corrupted/out-of-range coordinates. The unguarded push below used to
+                // put that `false` straight into map_markers[], which the view's DataTable then
+                // chokes on ("Requested unknown parameter 'id'...") since it's not a row object.
                 if (!empty($search_array['where'])) { // Select all records (advanced search) with where clause
                     if (in_array($display['id'], $records)) {
-                        $this->bean->map_markers[] = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                        $marker_data = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                        if (!empty($marker_data)) {
+                            $this->bean->map_markers[] = $marker_data;
+                        }
                     }
                 } elseif (!empty($_REQUEST['uid'])) { // Several records selected or this page selected
                     if (in_array($display['id'], $records)) {
-                        $this->bean->map_markers[] = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                        $marker_data = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                        if (!empty($marker_data)) {
+                            $this->bean->map_markers[] = $marker_data;
+                        }
                     }
                 } else { // All
-                    $this->bean->map_markers[] = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                    $marker_data = $this->getMarkerData($display_module, $display, false, $mod_strings_display);
+                    if (!empty($marker_data)) {
+                        $this->bean->map_markers[] = $marker_data;
+                    }
                 }
             }
         }

--- a/modules/jjwg_Maps/views/view.map_markers.php
+++ b/modules/jjwg_Maps/views/view.map_markers.php
@@ -84,7 +84,11 @@ class Jjwg_MapsViewMap_Markers extends SugarView
   </style>
   <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/datatables/1.9.4/css/jquery.dataTables.min.css" />
   <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/datatables-tabletools/2.1.5/css/TableTools.min.css" />
-  <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false&libraries=drawing,geometry"></script>
+  <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?key=<?= $GLOBALS['jjwg_config']['google_maps_api_key']; ?>&sensor=false&libraries=geometry"></script>
+  <!-- google.maps.drawing.DrawingManager was removed in Maps JavaScript API v3.65; Terra Draw is Google's
+       recommended replacement drawing engine (https://developers.google.com/maps/documentation/javascript/examples/map-drawing-terradraw) -->
+  <script type="text/javascript" src="//unpkg.com/terra-draw@1.32.3/dist/terra-draw.umd.js"></script>
+  <script type="text/javascript" src="//unpkg.com/terra-draw-google-maps-adapter@1.6.1/dist/terra-draw-google-maps-adapter.umd.js"></script>
   <script src="include/javascript/jquery/jquery-min.js"></script>
   <script type="text/javascript" src="modules/jjwg_Maps/javascript/jquery.iframe-auto-height.plugin.1.9.3.min.js"></script>
   <script type="text/javascript" src="modules/jjwg_Maps/javascript/markerclusterer_packed.js"></script>
@@ -193,8 +197,10 @@ var clusterControlDiv = null;
 // Clusterer Images - Protocol Independent
 MarkerClusterer.IMAGE_PATH = "//raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
-// Drawing Controls
-var drawingManager = null;
+// Drawing Controls (Terra Draw replaces the deprecated google.maps.drawing.DrawingManager)
+var terraDrawInstance = null;
+var terraDrawReady = false;
+var terraDrawActiveMode = null;
 var selectedShape = null;
 var selectedShapeMarkerById = null;
 
@@ -391,30 +397,133 @@ function setClusterControl() {
 function setDrawingControls() {
 
     // Drawing Controls
+    // Terra Draw (https://terradraw.io) replaces the deprecated google.maps.drawing.DrawingManager,
+    // which was removed from the Maps JavaScript API in v3.65. Terra Draw is only used to drive the
+    // interactive drawing of a new shape; as soon as a shape is finished it is converted into a real
+    // google.maps.Rectangle/Circle/Polygon overlay (see finishTerraDrawShape below) so that everything
+    // downstream (selection, editing, deletion, marker containment, DataTable filtering) keeps working
+    // against native Google Maps overlay objects exactly as it did before.
     var overlayOptions = { strokeColor: "#000099", strokeOpacity: 0.8, strokeWeight: 1, fillColor: "#000099", fillOpacity: 0.20, clickable: true, draggable: true, editable: true, zIndex: 5 };
-    drawingManager = new google.maps.drawing.DrawingManager({
-        drawingMode: null,
-        drawingControl: true,
-        drawingControlOptions: {
-            position: google.maps.ControlPosition.TOP_CENTER,
-            drawingModes: [
-                google.maps.drawing.OverlayType.RECTANGLE,
-                google.maps.drawing.OverlayType.CIRCLE,
-                google.maps.drawing.OverlayType.POLYGON
-            ]
-        },
-        rectangleOptions: overlayOptions,
-        circleOptions: overlayOptions,
-        polygonOptions: overlayOptions
-    });
-    drawingManager.setMap(map);
 
-    google.maps.event.addListener(drawingManager, 'overlaycomplete', function(e) {
-        // Switch back to non-drawing mode after drawing a shape
-        drawingManager.setDrawingMode(null);
-        // Add an event listeners
-        var newShape = e.overlay;
-        newShape.type = e.type;
+    function startTerraDraw() {
+        terraDrawInstance = new terraDraw.TerraDraw({
+            adapter: new terraDrawGoogleMapsAdapter.TerraDrawGoogleMapsAdapter({
+                lib: google.maps,
+                map: map,
+                coordinatePrecision: 9
+            }),
+            modes: [
+                new terraDraw.TerraDrawRectangleMode(),
+                new terraDraw.TerraDrawCircleMode(),
+                new terraDraw.TerraDrawPolygonMode()
+            ]
+        });
+
+        // The Google Maps adapter creates a google.maps.OverlayView which can only be positioned
+        // asynchronously, so drawing modes must not be enabled until the 'ready' event fires.
+        terraDrawInstance.on('ready', function() {
+            terraDrawReady = true;
+        });
+
+        terraDrawInstance.on('finish', function(id, context) {
+            if (context.action === 'draw') {
+                finishTerraDrawShape(id);
+            }
+        });
+
+        terraDrawInstance.start();
+    }
+
+    // The adapter needs the map's projection to be available; it is already available by this point
+    // in initialize() in the vast majority of cases, but fall back to waiting for the event just in case.
+    if (map.getProjection()) {
+        startTerraDraw();
+    } else {
+        google.maps.event.addListenerOnce(map, 'projection_changed', startTerraDraw);
+    }
+
+    function setActiveDrawingMode(mode) {
+        if (!terraDrawReady) {
+            return;
+        }
+        // Clear the current selection when the drawing mode is changed (previously handled by
+        // the DrawingManager's 'drawingmode_changed' event).
+        clearSelection();
+        terraDrawActiveMode = mode;
+        terraDrawInstance.setMode(mode ? mode : 'static');
+        for (var m in modeButtons) {
+            if (modeButtons.hasOwnProperty(m)) {
+                modeButtons[m].style.backgroundColor = (m === mode) ? '#e0e0e0' : '#ffffff';
+            }
+        }
+    }
+
+    function finishTerraDrawShape(id) {
+        var feature = terraDrawInstance.getSnapshotFeature(id);
+        // Remove the Terra Draw feature - it is replaced by a native overlay below.
+        terraDrawInstance.removeFeatures([id]);
+        // Switch back to non-drawing (pan) mode after drawing a shape
+        setActiveDrawingMode(null);
+
+        if (!feature) {
+            return;
+        }
+
+        var newShape = null;
+        var mode = feature.properties.mode;
+
+        if (mode == 'rectangle') {
+            var rRing = feature.geometry.coordinates[0];
+            var minLat = Infinity, maxLat = -Infinity, minLng = Infinity, maxLng = -Infinity;
+            for (var i = 0, rLen = rRing.length; i < rLen; i++) {
+                var rLng = rRing[i][0], rLat = rRing[i][1];
+                if (rLat < minLat) minLat = rLat;
+                if (rLat > maxLat) maxLat = rLat;
+                if (rLng < minLng) minLng = rLng;
+                if (rLng > maxLng) maxLng = rLng;
+            }
+            newShape = new google.maps.Rectangle(Object.assign({
+                map: map,
+                bounds: new google.maps.LatLngBounds(
+                    new google.maps.LatLng(minLat, minLng),
+                    new google.maps.LatLng(maxLat, maxLng)
+                )
+            }, overlayOptions));
+        } else if (mode == 'circle') {
+            var cRing = feature.geometry.coordinates[0];
+            var cMinLat = Infinity, cMaxLat = -Infinity, cMinLng = Infinity, cMaxLng = -Infinity;
+            for (var j = 0, cLen = cRing.length; j < cLen; j++) {
+                var cLng = cRing[j][0], cLat = cRing[j][1];
+                if (cLat < cMinLat) cMinLat = cLat;
+                if (cLat > cMaxLat) cMaxLat = cLat;
+                if (cLng < cMinLng) cMinLng = cLng;
+                if (cLng > cMaxLng) cMaxLng = cLng;
+            }
+            newShape = new google.maps.Circle(Object.assign({
+                map: map,
+                center: new google.maps.LatLng((cMinLat + cMaxLat) / 2, (cMinLng + cMaxLng) / 2),
+                radius: (feature.properties.radiusKilometers || 0) * 1000
+            }, overlayOptions));
+        } else if (mode == 'polygon') {
+            var pRing = feature.geometry.coordinates[0];
+            var path = [];
+            // Drop the closing coordinate (GeoJSON repeats the first point); google.maps.Polygon
+            // closes its own path automatically.
+            for (var k = 0, pLen = pRing.length - 1; k < pLen; k++) {
+                path.push(new google.maps.LatLng(pRing[k][1], pRing[k][0]));
+            }
+            newShape = new google.maps.Polygon(Object.assign({
+                map: map,
+                paths: path
+            }, overlayOptions));
+        }
+
+        if (!newShape) {
+            return;
+        }
+
+        // Add event listeners - identical to the original DrawingManager 'overlaycomplete' handler.
+        newShape.type = mode;
         google.maps.event.addListener(newShape, 'click', function() {
             setSelection(newShape);
         });
@@ -430,10 +539,53 @@ function setDrawingControls() {
             });
         }
         setSelection(newShape);
+    }
+
+    // Drawing Mode Buttons - replicate the old DrawingManager toolbar (TOP_CENTER)
+    var modeButtons = {};
+    var modeDefs = [
+        { mode: 'rectangle', label: 'Rectangle' },
+        { mode: 'circle', label: 'Circle' },
+        { mode: 'polygon', label: 'Polygon' }
+    ];
+
+    var drawingControlDiv = document.createElement('div');
+    drawingControlDiv.style.padding = '6px';
+    drawingControlDiv.style.display = 'flex';
+
+    modeDefs.forEach(function(def) {
+        var controlUI = document.createElement('div');
+        controlUI.style.backgroundColor = '#ffffff';
+        controlUI.style.borderStyle = 'solid';
+        controlUI.style.borderColor = '#a9a9a9';
+        controlUI.style.borderWidth = '1px';
+        controlUI.style.cursor = 'pointer';
+        controlUI.style.textAlign = 'center';
+        controlUI.style.marginRight = '4px';
+        controlUI.title = 'Click to Draw a ' + def.label;
+
+        var controlText = document.createElement('div');
+        controlText.style.fontFamily = 'Arial,Verdana,Helvetica,sans-serif';
+        controlText.style.fontSize = '12px';
+        controlText.style.paddingLeft = '4px';
+        controlText.style.paddingRight = '4px';
+        controlText.style.paddingTop = '4px';
+        controlText.style.paddingBottom = '4px';
+        controlText.innerHTML = def.label;
+        controlUI.appendChild(controlText);
+
+        drawingControlDiv.appendChild(controlUI);
+        modeButtons[def.mode] = controlUI;
+
+        google.maps.event.addDomListener(controlUI, 'click', function() {
+            setActiveDrawingMode(terraDrawActiveMode === def.mode ? null : def.mode);
+        });
     });
 
-    // Clear the current selection when the drawing mode is changed, or when the map is clicked.
-    google.maps.event.addListener(drawingManager, 'drawingmode_changed', clearSelection);
+    drawingControlDiv.index = 1;
+    map.controls[google.maps.ControlPosition.TOP_CENTER].push(drawingControlDiv);
+
+    // Clear the current selection when the map is clicked.
     google.maps.event.addListener(map, 'click', clearSelection);
 
 


### PR DESCRIPTION
## Description

This pull request restores the drawing functionality in the SuiteCRM Maps module by replacing the deprecated Google Maps Drawing Library with Terra Draw.

<img width="1209" height="513" alt="image" src="https://github.com/user-attachments/assets/89aab17e-53f0-43e8-9c6b-8681cfa3a34e" />


The Maps module previously relied on:

```javascript
google.maps.drawing.DrawingManager
```

This functionality is no longer available in current versions of the Google Maps JavaScript API, causing the drawing tools used by SuiteCRM Maps to stop working.

The implementation replaces `google.maps.drawing.DrawingManager` with **Terra Draw** using the Terra Draw Google Maps adapter.

Terra Draw is used for the interactive creation of new shapes. Once a shape has been completed, it is converted into the corresponding native Google Maps overlay:

```javascript
google.maps.Rectangle
google.maps.Circle
google.maps.Polygon
```

This approach allows the existing SuiteCRM Maps functionality to continue working with minimal changes to the existing logic.

In particular, the existing behaviour for the following functionality is preserved:

- Rectangle drawing
- Circle drawing
- Polygon drawing
- Shape selection
- Shape editing
- Shape deletion
- Marker containment inside drawn shapes
- DataTable filtering based on the selected geographic area
- Existing Google Maps markers and marker clustering

The Google Maps API is now loaded with the `geometry` library instead of the deprecated `drawing` library.

The Terra Draw libraries are loaded through:

```text
terra-draw
terra-draw-google-maps-adapter
```

The changes are limited to the following files:

```text
modules/jjwg_Maps/controller.php
modules/jjwg_Maps/views/view.map_markers.php
```

## Motivation and Context

The SuiteCRM Maps module depends on the Google Maps Drawing Library for drawing geographic areas on the map.

The previous implementation uses `google.maps.drawing.DrawingManager`, which is no longer available in current Google Maps JavaScript API versions.

As a consequence, users can no longer use the Maps drawing controls to create rectangles, circles or polygons for selecting and filtering CRM records geographically.

This change restores that functionality using Terra Draw.

The implementation was designed to minimise the impact on the existing SuiteCRM Maps code.

Terra Draw is responsible only for the interactive drawing phase. After a shape has been completed, it is converted to the same native Google Maps overlay objects that the existing SuiteCRM code expects.

This means that the existing logic for editing, deleting, selecting shapes and filtering records can continue to operate without requiring a complete rewrite of the Maps module.

## How To Test This

1. Install or update SuiteCRM using the changes from this pull request.
2. Configure a valid Google Maps API key in SuiteCRM.
3. Ensure that some Accounts, Contacts, Leads or other supported records have valid geocoded coordinates.
4. Open the **Maps** module.
5. Display a map containing geocoded CRM records.
6. Verify that the drawing controls are displayed on the map.
7. Select the rectangle drawing tool.
8. Draw a rectangle around some CRM markers.
9. Verify that:
   - the rectangle is displayed correctly;
   - the shape can be selected;
   - records contained inside the rectangle are correctly identified/filtered.
10. Select the circle drawing tool.
11. Draw a circle around some CRM markers.
12. Verify that:
    - the circle is displayed correctly;
    - records inside the circle are correctly identified/filtered.
13. Select the polygon drawing tool.
14. Draw a polygon around some CRM markers.
15. Verify that:
    - the polygon is displayed correctly;
    - records inside the polygon are correctly identified/filtered.
16. Verify that a completed shape can be selected.
17. Verify that an existing shape can be edited.
18. Verify that an existing shape can be deleted.
19. Verify that switching between Rectangle, Circle and Polygon drawing modes works correctly.
20. Verify that after completing a shape the map returns to normal navigation mode.
21. Verify that normal Google Maps markers continue to be displayed correctly.
22. Verify that marker clustering continues to work.
23. Verify that the existing Maps DataTable filtering functionality continues to work.



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.