### PR TITLE
Fix #10914 - Fix url for maps in both SuitCRM 7 & 8

### DIFF
--- a/modules/jjwg_Maps/views/view.map_display.php
+++ b/modules/jjwg_Maps/views/view.map_display.php
@@ -19,7 +19,7 @@ class Jjwg_MapsViewMap_Display extends SugarView
     {
         // Limit URI query string parameters. Used to avoid URL length errors.
         $valid_names = array('action', 'module', 'entryPoint', 'submit', 'cron', 'geocoding_process', 'process_trigger', 'distance', 'unit_type', 'record', 'related_id', 'related_module', 'quick_address', 'display_module', 'list_id', 'uid', 'current_post');
-        $url = $GLOBALS['sugar_config']['site_url'] . '/index.php?module=' . $GLOBALS['currentModule'] . '&action=map_markers';
+        $url = 'index.php?module=' . $GLOBALS['currentModule'] . '&action=map_markers';
         foreach (array_keys($_REQUEST) as $key) {
             if (in_array($key, $valid_names) && !in_array($key, array('action', 'module', 'entryPoint'))) {
                 $url .= '&'.$key.'='.urlencode((string)$_REQUEST[$key]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
This fixes the URL for google maps so that it relies on the current working directory instead of using the url in the configuration file. This works on both SuiteCRM 7 & 8 .

## Motivation and Context
SuiteCRM 8 points to the wrong index.php file in order to display maps because it relies on the 'site_url' configuration option which is different for SuiteCRM 7. 
Please see: #10914

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->