### PR TITLE
Fixed #10912 - V8 API datetimes returned without seconds

### DIFF
--- a/Api/V8/BeanDecorator/BeanManager.php
+++ b/Api/V8/BeanDecorator/BeanManager.php
@@ -62,6 +62,9 @@ class BeanManager
      */
     public function getBean($module, $id = null, array $params = [], $deleted = true)
     {
+        global $disable_date_format;
+        $disable_date_format = true;
+
         return \BeanFactory::getBean($module, $id, $params, $deleted);
     }
 


### PR DESCRIPTION
### Description
Sets the `$disable_date_format` global to `true` before loading a bean in `Api/V8/BeanDecorator/BeanManager::getBean()`. Without this, `SugarBean`'s date/datetime fields are formatted for display (which truncates seconds) instead of returning raw DB values, causing V8 REST API responses to always show `:00` seconds regardless of the actual stored value.

### Motivation and Context
Fixes #10912. Legacy SOAP/v3 API endpoints already set this same global before bean retrieval (see `service/core/SoapHelperWebService.php:47` and `service/v3/SugarWebServiceUtilv3.php:93`) — the V8 REST API was missing the equivalent handling.

### How To Test
1. Create/update a record with a `date_modified` or `date_entered` value that has non-zero seconds in the DB.
2. Retrieve the record via the V8 REST API (`GET /Api/V8/module/{module}/{id}`).
3. Confirm the returned datetime attribute preserves the actual seconds instead of showing `:00`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Final checklist
- [x] My code follows the code style of this project found here.
- [ ] My change requires a change to the documentation.
- [x] I have read the How to Contribute guidelines.